### PR TITLE
chore: normalize contributor attribution

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+# Canonicalize stale AI-tool co-author metadata to the repository owner.
+Adisorn <engasnm111@users.noreply.github.com> Cursor <cursoragent@cursor.com>


### PR DESCRIPTION
## Summary
- add a `.mailmap` entry that canonicalizes the stale `Cursor <cursoragent@cursor.com>` co-author trailer to the repository owner
- avoids rewriting published Git history or invalidating release/tag SHAs

## Verification
- `git check-mailmap "Cursor <cursoragent@cursor.com>"` resolves to the repository owner
- `git shortlog -sne --group=trailer:co-authored-by origin/main` groups all four stale co-author trailers under the repository owner

GitHub's Contributors graph is cached, so the UI may take time to recalculate after this reaches the default branch.