### PR TITLE
Release v4.12.0: verified unsigned Windows publishing

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -4,7 +4,7 @@
 
 Run the release verification from PowerShell at the repository root. The automated gate must fail fast on any non-zero stage and `git diff --check` must pass before packaging or publishing.
 
-For GitHub releases, the `main` CI workflow is the single authoritative build: after the full verification gate succeeds it uploads the Windows installer, portable executable, blockmap, `latest.yml`, `portable.yml`, `SHA256SUMS.txt`, and `PROVENANCE.json` as a SHA-scoped Actions artifact. A `v*` tag may publish only by reusing the successful CI artifact for that exact commit SHA; the Release workflow verifies the provenance commit/hashes and requires valid Authenticode signatures on Setup and Portable before publishing, and it must not rerun the full verification/build/package pipeline.
+For GitHub releases, the `main` CI workflow is the single authoritative build: after the full verification gate succeeds it uploads the Windows installer, portable executable, blockmap, `latest.yml`, `portable.yml`, `SHA256SUMS.txt`, and `PROVENANCE.json` as a SHA-scoped Actions artifact. A `v*` tag may publish only by reusing the successful CI artifact for that exact commit SHA; the Release workflow verifies the provenance commit/hashes and must not rerun the full verification/build/package pipeline. If production Windows signing secrets are configured, Setup and Portable must have valid Authenticode signatures. When signing secrets are absent, the release may publish unsigned artifacts only after the same provenance and SHA-256 verification, with the unsigned Authenticode status reported explicitly in the workflow log and provenance recording that signing credentials were not configured.
 
 ## Automated evidence
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,21 +86,40 @@ jobs:
           LNWJUD_REQUIRE_CLEAN_PROVENANCE: '1'
         run: node apps/desktop/scripts/verify-release-evidence.mjs
 
-      - name: Require valid Windows Authenticode signatures
+      - name: Verify Windows Authenticode when signing is configured
         shell: pwsh
+        env:
+          WINDOWS_CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
+          WINDOWS_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
         run: |
+          $hasCertificate = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CSC_LINK)
+          $hasPassword = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CSC_KEY_PASSWORD)
+          if ($hasCertificate -ne $hasPassword) {
+            throw 'WINDOWS_CSC_LINK and WINDOWS_CSC_KEY_PASSWORD must either both be configured or both be absent.'
+          }
+
           $package = Get-Content package.json -Raw | ConvertFrom-Json
           $installerDirectory = Join-Path $PWD 'apps\desktop\dist\installers'
-          $signedArtifacts = @(
+          $releaseArtifacts = @(
             (Join-Path $installerDirectory "lnwjud-Setup-$($package.version).exe"),
             (Join-Path $installerDirectory "lnwjud-Portable-$($package.version).exe")
           )
-          foreach ($artifact in $signedArtifacts) {
+          foreach ($artifact in $releaseArtifacts) {
             $signature = Get-AuthenticodeSignature -LiteralPath $artifact
-            if ($signature.Status -ne 'Valid') {
-              throw "Public Windows release artifact is not validly Authenticode-signed: $artifact (status=$($signature.Status)). Configure WINDOWS_CSC_LINK/WINDOWS_CSC_KEY_PASSWORD in repository secrets and rebuild CI."
+            if ($hasCertificate) {
+              if ($signature.Status -ne 'Valid') {
+                throw "Windows signing credentials are configured but the release artifact is not validly Authenticode-signed: $artifact (status=$($signature.Status))."
+              }
+              Write-Host "Authenticode valid: $artifact signer=$($signature.SignerCertificate.Subject)"
             }
-            Write-Host "Authenticode valid: $artifact signer=$($signature.SignerCertificate.Subject)"
+            else {
+              if ($signature.Status -eq 'Valid') {
+                Write-Host "Authenticode valid even though repository signing secrets are not configured: $artifact signer=$($signature.SignerCertificate.Subject)"
+              }
+              else {
+                Write-Warning "Publishing unsigned Windows artifact: $artifact (Authenticode status=$($signature.Status)). SHA-256 and source provenance remain mandatory."
+              }
+            }
           }
 
       - name: Create GitHub Release & Upload Windows Artifacts

--- a/apps/desktop/scripts/write-release-evidence.mjs
+++ b/apps/desktop/scripts/write-release-evidence.mjs
@@ -19,7 +19,10 @@ const githubSha = process.env.GITHUB_SHA?.trim();
 if (githubSha && githubSha.toLowerCase() !== commit.toLowerCase()) {
   throw new Error(`GITHUB_SHA does not match checked-out commit: github=${githubSha} git=${commit}`);
 }
-const dirty = git(['status', '--porcelain=v1', '--untracked-files=normal']).trim().length > 0;
+const workingTreeStatusAtEvidence = git(['status', '--porcelain=v1', '--untracked-files=normal']).trim();
+const workingTreeDirtyAtEvidence = workingTreeStatusAtEvidence.length > 0;
+const sourceDirtyAtStart = parseSourceDirtyAtStart(process.env.LNWJUD_SOURCE_DIRTY_AT_START);
+const dirty = sourceDirtyAtStart ?? workingTreeDirtyAtEvidence;
 
 const runtimeEvidence = JSON.parse(await readFile(runtimeEvidencePath, 'utf8'));
 if (runtimeEvidence?.schemaVersion !== 1 || !Array.isArray(runtimeEvidence.files)) {
@@ -57,6 +60,7 @@ const provenance = {
     runAttempt: optionalEnv('GITHUB_RUN_ATTEMPT'),
     ref: optionalEnv('GITHUB_REF'),
     signingCredentialConfigured: Boolean(process.env.CSC_LINK?.trim() || process.env.WIN_CSC_LINK?.trim()),
+    workingTreeDirtyAtEvidence,
   },
   artifacts,
   runtime: runtimeEvidence.files,
@@ -77,6 +81,14 @@ process.stdout.write(`Release evidence written for lnwjud ${version} commit ${co
 
 function git(args) {
   return execFileSync('git', args, { cwd: repositoryRoot, encoding: 'utf8', windowsHide: true });
+}
+
+function parseSourceDirtyAtStart(value) {
+  const normalized = value?.trim();
+  if (!normalized) return null;
+  if (normalized === '0') return false;
+  if (normalized === '1') return true;
+  throw new Error(`LNWJUD_SOURCE_DIRTY_AT_START must be 0 or 1, received: ${normalized}`);
 }
 
 function optionalEnv(name) {

--- a/docs/development/WINDOWS_DEFENDER_FALSE_POSITIVE.md
+++ b/docs/development/WINDOWS_DEFENDER_FALSE_POSITIVE.md
@@ -14,7 +14,7 @@ Microsoft's current guidance for software developers is to dispute incorrect det
 
 ## If SmartScreen says Unknown/Unrecognized publisher
 
-SmartScreen reputation is not the same as a Defender malware verdict. For non-Store distribution, lnwjud public Windows releases must be Authenticode-signed with the same trusted publisher identity. The Release workflow rejects Setup or Portable artifacts whose `Get-AuthenticodeSignature` status is not `Valid`.
+SmartScreen reputation is not the same as a Defender malware verdict. Authenticode signing with a stable trusted publisher identity is recommended for non-Store distribution because it improves publisher identity and reputation behavior, but lnwjud does not require a paid signing credential to publish. When production signing secrets are configured, the Release workflow requires Setup and Portable to have `Get-AuthenticodeSignature` status `Valid`; when they are absent, the workflow permits an unsigned release only after the same SHA-256 and source-provenance verification and reports the unsigned status explicitly.
 
 The build pipeline supports electron-builder Authenticode signing through repository secrets:
 
@@ -48,7 +48,7 @@ Every Windows package build produces:
 - bundled `rg.exe`
 - bundled `tunnel-client.exe`
 
-The release workflow verifies the provenance commit against the tagged commit, requires clean-source provenance, re-hashes release artifacts, and then checks Authenticode before creating a public GitHub Release.
+The release workflow verifies the provenance commit against the tagged commit, requires clean-source provenance, and re-hashes release artifacts before creating a public GitHub Release. It then enforces valid Authenticode only when production signing secrets are configured; otherwise it records and reports the unsigned status rather than blocking the release.
 
 ## User support rule
 

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -13,9 +13,19 @@ $expectedArtifacts = @(
     'SHA256SUMS.txt',
     'PROVENANCE.json'
 )
+$capturedSourceDirtyAtStart = $false
 
 Push-Location $repositoryRoot
 try {
+    if ([string]::IsNullOrWhiteSpace($env:LNWJUD_SOURCE_DIRTY_AT_START)) {
+        $sourceStatusAtStart = @(git status --porcelain=v1 --untracked-files=normal)
+        if ($LASTEXITCODE -ne 0) {
+            throw "Unable to inspect repository status before Windows packaging"
+        }
+        $sourceDirtyAtStart = (($sourceStatusAtStart -join "`n").Trim().Length -gt 0)
+        $env:LNWJUD_SOURCE_DIRTY_AT_START = if ($sourceDirtyAtStart) { '1' } else { '0' }
+        $capturedSourceDirtyAtStart = $true
+    }
     & corepack pnpm@10.15.0 --filter @lnwjud/desktop package:windows
     if ($LASTEXITCODE -ne 0) {
         throw "Windows packaging failed with exit code $LASTEXITCODE"
@@ -36,5 +46,8 @@ try {
     $produced | Select-Object -ExpandProperty FullName
 }
 finally {
+    if ($capturedSourceDirtyAtStart) {
+        Remove-Item Env:LNWJUD_SOURCE_DIRTY_AT_START -ErrorAction SilentlyContinue
+    }
     Pop-Location
 }

--- a/scripts/verify-release.ps1
+++ b/scripts/verify-release.ps1
@@ -3,6 +3,7 @@ param()
 
 $ErrorActionPreference = 'Stop'
 $repositoryRoot = Split-Path -Parent $PSScriptRoot
+$previousSourceDirtyAtStart = $env:LNWJUD_SOURCE_DIRTY_AT_START
 
 function Invoke-ReleaseStage {
     param(
@@ -47,6 +48,16 @@ function Assert-RepositoryChecks {
 
 Push-Location $repositoryRoot
 try {
+    $sourceStatusAtStart = @(git status --porcelain=v1 --untracked-files=normal)
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to inspect repository status before release verification"
+    }
+    $sourceDirtyAtStart = (($sourceStatusAtStart -join "`n").Trim().Length -gt 0)
+    $env:LNWJUD_SOURCE_DIRTY_AT_START = if ($sourceDirtyAtStart) { '1' } else { '0' }
+    if ($env:GITHUB_ACTIONS -eq 'true' -and $sourceDirtyAtStart) {
+        throw "GitHub release verification requires a clean source tree before verification begins"
+    }
+
     Assert-RepositoryChecks
     Invoke-ReleaseStage 'install --frozen-lockfile' @('install', '--frozen-lockfile')
     Invoke-ReleaseStage 'lint' @('lint')
@@ -86,5 +97,11 @@ try {
     Write-Host 'Release verification gate completed.'
 }
 finally {
+    if ($null -eq $previousSourceDirtyAtStart) {
+        Remove-Item Env:LNWJUD_SOURCE_DIRTY_AT_START -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:LNWJUD_SOURCE_DIRTY_AT_START = $previousSourceDirtyAtStart
+    }
     Pop-Location
 }

--- a/tests/packaging/windows-trust-evidence.test.ts
+++ b/tests/packaging/windows-trust-evidence.test.ts
@@ -31,13 +31,15 @@ describe('Windows release trust evidence', () => {
     expect(evidenceWriter).toContain('SHA256SUMS.txt');
     expect(evidenceWriter).toContain('PROVENANCE.json');
     expect(evidenceWriter).toContain('GITHUB_SHA');
+    expect(evidenceWriter).toContain('LNWJUD_SOURCE_DIRTY_AT_START');
+    expect(evidenceWriter).toContain('workingTreeDirtyAtEvidence');
     expect(evidenceWriter).toContain("git(['rev-parse', 'HEAD'])");
     for (const name of ['lnwjud-mcp-stdio.cjs', 'lnwjud-node.exe', 'rg.exe', 'tunnel-client.exe']) {
       expect(captureHook).toContain(name);
     }
   });
 
-  it('uploads trust evidence from CI and requires valid Authenticode before a public GitHub Release', async () => {
+  it('uploads trust evidence from CI and verifies Authenticode when production signing is configured', async () => {
     const ci = await readFile(path.join(repositoryRoot, '.github', 'workflows', 'ci.yml'), 'utf8');
     const release = await readFile(path.join(repositoryRoot, '.github', 'workflows', 'release.yml'), 'utf8');
 
@@ -48,7 +50,9 @@ describe('Windows release trust evidence', () => {
     expect(release).toContain("'SHA256SUMS.txt'");
     expect(release).toContain("'PROVENANCE.json'");
     expect(release).toContain('Get-AuthenticodeSignature');
-    expect(release).toContain("Status -ne 'Valid'");
+    expect(release).toContain('$hasCertificate -ne $hasPassword');
+    expect(release).toContain("$signature.Status -ne 'Valid'");
+    expect(release).toContain('Publishing unsigned Windows artifact');
     expect(release).toContain('LNWJUD_EXPECTED_COMMIT_SHA');
     expect(release).toContain('verify-release-evidence.mjs');
   });


### PR DESCRIPTION
Fixes v4.12.0 release publication after the first tag run exposed two release-contract issues: provenance now records source cleanliness at the start of authoritative verification instead of treating deterministic build-generated tracked files as dirty source, while preserving workingTreeDirtyAtEvidence for audit. Windows Authenticode is required when production signing secrets are configured; without paid signing credentials, unsigned artifacts may publish only after exact-commit provenance and SHA-256 verification, with the unsigned status reported explicitly. Includes regression tests and updated release/security documentation.