### PR TITLE
Release v4.12.0

### DIFF
--- a/apps/cli/src/runtime/stdio-mcp-runtime.test.ts
+++ b/apps/cli/src/runtime/stdio-mcp-runtime.test.ts
@@ -25,7 +25,12 @@ beforeEach(() => {
 afterEach(async () => {
   delete process.env.TUNNEL_CLIENT_PROFILE_DIR;
   delete process.env.LNWJUD_CHECKPOINT_KEY_BASE64;
-  await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, {
+    recursive: true,
+    force: true,
+    maxRetries: process.platform === 'win32' ? 5 : 0,
+    retryDelay: 100,
+  })));
 });
 
 describe('stdio MCP runtime', () => {

--- a/apps/desktop/e2e/desktop-dashboard.e2e.ts
+++ b/apps/desktop/e2e/desktop-dashboard.e2e.ts
@@ -144,7 +144,11 @@ async function waitForDevTools(port: number, child: ChildProcess, stderr: string
 
 async function terminateProcessTree(child: ChildProcess): Promise<void> {
   if (child.pid !== undefined) {
-    spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { shell: false, windowsHide: true });
+    const killer = spawn('taskkill.exe', ['/PID', String(child.pid), '/T', '/F'], { shell: false, windowsHide: true });
+    await new Promise<void>((resolve) => {
+      killer.once('error', () => resolve());
+      killer.once('close', () => resolve());
+    });
   }
   await new Promise<void>((resolve) => {
     if (child.exitCode !== null) {
@@ -157,7 +161,14 @@ async function terminateProcessTree(child: ChildProcess): Promise<void> {
 }
 
 async function removeTemporaryRoot(root: string): Promise<void> {
-  await rm(root, { recursive: true, force: true });
+  await expect.poll(async () => {
+    try {
+      await rm(root, { recursive: true, force: true });
+      return true;
+    } catch {
+      return false;
+    }
+  }, { timeout: 10_000, intervals: [50, 100, 250] }).toBe(true);
 }
 
 async function expectNoHorizontalOverflow(page: Page): Promise<void> {

--- a/apps/desktop/e2e/guided-tunnel-setup.e2e.ts
+++ b/apps/desktop/e2e/guided-tunnel-setup.e2e.ts
@@ -58,7 +58,7 @@ async function ensureThaiLocale(page: Page): Promise<void> {
   });
   await expect.poll(async () => page.evaluate(async () => (
     await window.lnwjud.getDashboard()
-  ).locale)).toBe('th');
+  ).locale), { timeout: 15_000, intervals: [100, 250, 500] }).toBe('th');
 }
 
 async function withFreshDesktop(run: (page: Page) => Promise<void>): Promise<void> {

--- a/apps/desktop/tests/multi-workspace-concurrency-acceptance.test.ts
+++ b/apps/desktop/tests/multi-workspace-concurrency-acceptance.test.ts
@@ -321,7 +321,7 @@ async function waitForTerminalShellTask(
 }
 
 async function waitForTerminalProcess(client: Client, workspaceId: string, processId: string): Promise<Record<string, unknown>> {
-  const deadline = Date.now() + 15_000;
+  const deadline = Date.now() + (process.env.CI ? 45_000 : 15_000);
   while (Date.now() < deadline) {
     const response = await client.callTool({
       name: 'process_status',

--- a/packages/capabilities/src/durable-shell-task-store.test.ts
+++ b/packages/capabilities/src/durable-shell-task-store.test.ts
@@ -8,7 +8,12 @@ import { DurableShellTaskStore } from './durable-shell-task-store.js';
 const temporaryRoots: string[] = [];
 
 afterEach(async () => {
-  await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, {
+    recursive: true,
+    force: true,
+    maxRetries: process.platform === 'win32' ? 5 : 0,
+    retryDelay: 100,
+  })));
 });
 
 describe('durable shell background tasks', () => {

--- a/packages/capabilities/src/durable-shell-task-store.ts
+++ b/packages/capabilities/src/durable-shell-task-store.ts
@@ -131,7 +131,10 @@ export class DurableShellTaskStore {
       await writeFile(specPath, JSON.stringify(spec), 'utf8');
       const workerPath = await this.ensureWorkerScript();
       const worker = spawn(process.execPath, [workerPath, specPath], {
-        cwd: request.cwd,
+        // The durable worker only coordinates the real child process; it does not need
+        // the workspace as its own cwd. Keeping the worker outside the workspace avoids
+        // a transient Windows directory lock after the child has already completed.
+        cwd: path.dirname(process.execPath),
         detached: true,
         stdio: 'ignore',
         shell: false,

--- a/packages/storage/vitest.config.ts
+++ b/packages/storage/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    testTimeout: process.env.CI ? 20_000 : 5_000,
+    hookTimeout: process.env.CI ? 20_000 : 10_000,
+  },
+});


### PR DESCRIPTION
Prepare v4.12.0 release from release/v4.12.0-rc. Includes the storage Vitest CI timeout fix so Windows CI has enough headroom without changing local defaults or weakening assertions.