### PR TITLE
release: v4.12.1 tunnel continuity hotfix

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -1,6 +1,6 @@
 # lnwjud Release Checklist
 
-**Current version:** `v4.12.0` - Windows installer `lnwjud-Setup-4.12.0.exe` and portable executable `lnwjud-Portable-4.12.0.exe`; MCP registry **223 configurable tools / 217 advertised by default**.
+**Current version:** `v4.12.1` - Windows installer `lnwjud-Setup-4.12.1.exe` and portable executable `lnwjud-Portable-4.12.1.exe`; MCP registry **223 configurable tools / 217 advertised by default**.
 
 Run the release verification from PowerShell at the repository root. The automated gate must fail fast on any non-zero stage and `git diff --check` must pass before packaging or publishing.
 
@@ -12,7 +12,7 @@ For GitHub releases, the `main` CI workflow is the single authoritative build: a
 - Secret-file policy and log/incident redaction tests pass; release evidence must never contain credentials or tokens.
 - MCP local HTTP and STDIO transport tests pass, including protocol-only stdout and production handshake coverage.
 - OpenAI Secure Tunnel targets the Desktop loopback HTTP MCP (`sample_mcp_remote_no_auth`) rather than a separate headless stdio runtime, preserving dynamic Active Project scope and native exact-action approval.
-- v4.11 persistent-tunnel acceptance preserves one saved tunnel identity across managed-runtime loss and Desktop/local-MCP rebinding; transient retry is capped but unbounded in count, while auth/operator failures do not tight-loop.
+- Persistent-tunnel acceptance preserves one saved tunnel identity across managed-runtime loss, Desktop/local-MCP rebinding, update/reinstall startup, and detached-runtime handoff; transient retry is capped but unbounded in count, while auth/operator failures do not tight-loop.
 - The installed official tunnel client capability probe must show managed `runtimes connect/status/stop` plus health/readiness/control-plane-poll support. Strict zero-downtime may be claimed only if a ready-before-retire overlap primitive is actually proven; otherwise the product must display the capability limitation.
 - The 2026-07-28 MCP protocol catalog is compared before/after Desktop MCP listener restart: all 217 default descriptors and their canonical SHA-256 digest must remain identical, and a production tool call must work on both sides of the restart.
 - Durable task/session resilience remains independent from one tunnel request; release evidence must not kill a user's live connector merely to manufacture a continuity result.
@@ -37,7 +37,7 @@ For GitHub releases, the `main` CI workflow is the single authoritative build: a
 
 On a clean Windows account or VM, install and launch the packaged application, confirm first-run data creation, exercise a disposable workspace and Doctor, close the application, then uninstall it. Separately launch `lnwjud-Portable-<version>.exe` without installing it and confirm the dashboard, bundled runtime assets, workspace scope, and tunnel controls initialize normally. Record only pass/fail status, OS architecture, artifact path, and relevant error codes.
 
-For the v4.11 tunnel candidate, perform the final ChatGPT Web continuity check with the same configured tunnel and conversation: do not refresh the connector, do not create a replacement tunnel/chat, cause one real supported reconnect/restart event, and confirm the next tool call succeeds. This manual Windows artifact check is the release boundary for end-to-end ChatGPT Web continuity.
+For the current tunnel release candidate, perform the final ChatGPT Web continuity check with the same configured tunnel and existing conversation: do not refresh the connector, do not create a replacement tunnel/chat, perform a normal Desktop restart or supported update/reinstall handoff, and confirm the next tool call succeeds with the same Tunnel ID. This manual Windows artifact check is the release boundary for end-to-end ChatGPT Web continuity.
 
 Run one low-impact real Codex discovery/delegation check only in a disposable Git fixture. Do not automate provider quota consumption and do not read Codex credential files.
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ over outbound HTTPS, forwards MCP work to lnwjud's Desktop loopback HTTP MCP,
 and returns the response without opening a public inbound port on the Windows
 machine.
 
-## Current version: v4.12.0
+## Current version: v4.12.1
 
-The v4.12.0 release target and runtime contract contain **223 configurable MCP tools**,
+The v4.12.1 release target and runtime contract contain **223 configurable MCP tools**,
 with **217 advertised by default** because
 the six `codex_*` delegation tools are opt-in. The earlier 184-tool snapshot remains
 only as the compatibility baseline used by the v4 architecture; new v4 gateway
@@ -57,6 +57,15 @@ capabilities are additive.
 - Adds resume/recovery behavior based on real tunnel status. Existing configured users are not interrupted, dismissed users can reopen the guide from Home or Settings, and in-progress setup resumes at the first step still required by the local key/profile/runtime state.
 - Keeps secrets local: onboarding storage contains only a finite UI state, Runtime API key drafts are cleared after a successful save or guide close, and status/summary UI uses only masked Tunnel IDs.
 - Adds focused unit/IPC/renderer coverage plus a real isolated Electron E2E smoke for first-run Tips, Secure Tunnel navigation, language switching, and the Set up later/reopen flow.
+
+#### Hotfix v4.12.1
+
+- Fixes a v4.12.0 regression where Desktop startup during an update/reinstall could stop an already-surviving persistent tunnel when a local prerequisite was temporarily unavailable. Startup is now recovery-only and never tears down that saved tunnel identity.
+- Preserves the **same Tunnel ID, profile, and DPAPI-protected Runtime API key** across normal app restart, in-place update, reinstall, and Desktop reconnect. The existing tunnel is reconciled/rebound to the current local MCP endpoint instead of provisioning a replacement identity.
+- Treats a configured detached persistent runtime as **Running** even while it is temporarily reported as `source=external`, so Home, Settings, and the setup guide agree on the live tunnel state.
+- Prevents previously configured users from being redirected into **Settings > Secure Tunnel** after an update/reinstall. Stale `in_progress` onboarding state is normalized from the real saved tunnel prerequisites.
+- Prevents the setup guide from offering a duplicate **Start Tunnel** step when the preserved tunnel is already running; reopening the guide goes directly to the ChatGPT connection step.
+- Adds regression coverage for reinstall/startup prerequisite gaps, detached-runtime recognition, onboarding continuity, and reuse of the existing tunnel without automatic stop/replacement.
 
 Current v4 highlights include:
 
@@ -151,13 +160,13 @@ stops the current local HTTP listener.
 
 1. Download the latest published installer from
    [GitHub Releases](https://github.com/engasnm111/lnwjud/releases/latest).
-   Current Windows 10/11 x64 artifacts are `lnwjud-Setup-4.12.0.exe` (recommended installer) and `lnwjud-Portable-4.12.0.exe` (no installation required).
+   Current Windows 10/11 x64 artifacts are `lnwjud-Setup-4.12.1.exe` (recommended installer) and `lnwjud-Portable-4.12.1.exe` (no installation required).
 2. Run the NSIS installer and launch **lnwjud Agent Control Center**.
 3. Add or select the project/workspace you want lnwjud to operate on.
 4. Review **Settings** before attaching an AI client, especially Permission
    Profile and Unrestricted Mode.
 
-If you prefer not to install the app, run `lnwjud-Portable-4.11.0.exe` directly.
+If you prefer not to install the app, run `lnwjud-Portable-4.12.1.exe` directly.
 Portable mode uses the same per-user lnwjud data/settings location as the installer;
 it is a portable executable, not a keep-all-data-next-to-the-EXE mode.
 Automatic updates preserve the distribution you chose. Installer users read
@@ -283,8 +292,8 @@ Secure Tunnel จะส่งงานเข้าที่ Desktop loopback HTT
 
 ### 1. ติดตั้ง lnwjud หรือใช้ Portable
 
-1. แบบแนะนำ: ดาวน์โหลด `lnwjud-Setup-4.11.0.exe` แล้วติดตั้งตามปกติ
-2. ถ้าไม่ต้องการติดตั้ง: ดาวน์โหลด `lnwjud-Portable-4.11.0.exe` แล้วเปิดได้ทันที
+1. แบบแนะนำ: ดาวน์โหลด `lnwjud-Setup-4.12.1.exe` แล้วติดตั้งตามปกติ
+2. ถ้าไม่ต้องการติดตั้ง: ดาวน์โหลด `lnwjud-Portable-4.12.1.exe` แล้วเปิดได้ทันที
 3. เปิด **lnwjud Agent Control Center**
 4. เพิ่มหรือเลือก Project/Workspace ที่ต้องการให้ ChatGPT ทำงานด้วย
 
@@ -299,7 +308,7 @@ Portable ใช้ Settings/ข้อมูลต่อผู้ใช้ Window
 
 ### 3. tunnel-client มากับตัวติดตั้งแล้ว
 
-ถ้าใช้ `lnwjud-Setup-4.11.0.exe` หรือ `lnwjud-Portable-4.11.0.exe` บน Windows x64 **ไม่ต้องดาวน์โหลด
+ถ้าใช้ `lnwjud-Setup-4.12.1.exe` หรือ `lnwjud-Portable-4.12.1.exe` บน Windows x64 **ไม่ต้องดาวน์โหลด
 `tunnel-client.exe` เอง** ตัว release รวม official OpenAI
 `tunnel-client v0.0.12` มาให้และ lnwjud จะเลือกใช้ให้อัตโนมัติ
 
@@ -512,8 +521,8 @@ corepack pnpm@10.15.0 package:windows
 The Windows 10/11 x64 artifacts are written to:
 
 ```text
-apps/desktop/dist/installers/lnwjud-Setup-4.12.0.exe
-apps/desktop/dist/installers/lnwjud-Portable-4.12.0.exe
+apps/desktop/dist/installers/lnwjud-Setup-4.12.1.exe
+apps/desktop/dist/installers/lnwjud-Portable-4.12.1.exe
 ```
 
 The installer is per-user by default. The portable executable needs no installation but uses the same per-user lnwjud data/settings location. A common installed executable path is:

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/cli",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/desktop",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "description": "Windows-first local AI-agent runtime and MCP gateway with 223 configurable tools.",
   "author": "Adisorn",

--- a/apps/desktop/src/main/desktop-services.ts
+++ b/apps/desktop/src/main/desktop-services.ts
@@ -167,6 +167,25 @@ export interface DesktopRuntimeOptions {
   readonly hostMutationApprovalProvider?: (request: HostMutationApprovalRequest) => boolean | Promise<boolean>;
 }
 
+interface StartupTunnelController {
+  status(): Promise<TunnelStatus>;
+  startAutomatically(): Promise<TunnelStatus>;
+}
+
+/**
+ * Desktop startup is recovery-only: it may start/reconcile the saved tunnel,
+ * but it must never stop a surviving persistent runtime merely because a local
+ * prerequisite is temporarily unavailable during an update or reinstall.
+ */
+export async function autoStartPersistentTunnel(
+  tunnelController: StartupTunnelController,
+  autoReconnect: boolean,
+): Promise<TunnelStatus> {
+  const status = await tunnelController.status();
+  if (!autoReconnect || !status.profileExists || !status.hasApiKey || status.clientPath === null) return status;
+  return tunnelController.startAutomatically();
+}
+
 export function createDesktopRuntime(dataPath: string, options: DesktopRuntimeOptions = {}): DesktopRuntime {
   const databaseFilename = path.join(dataPath, 'lnwjud.sqlite');
   const backupDirectory = path.join(dataPath, 'backups');
@@ -927,15 +946,10 @@ export function createDesktopRuntime(dataPath: string, options: DesktopRuntimeOp
       await activateWorkspace(selected.id);
       return mcpLifecycle.start();
     },
-    autoStartTunnel: async (): Promise<TunnelStatus | null> => {
-      const settings = readSettings();
-      const status = await tunnelController.status();
-      if (!settings.tunnelAutoReconnect || !status.profileExists || !status.hasApiKey || status.clientPath === null) {
-        await tunnelController.stopPersistedNativeRuntimeIfOwned();
-        return tunnelController.status();
-      }
-      return tunnelController.startAutomatically();
-    },
+    autoStartTunnel: async (): Promise<TunnelStatus | null> => autoStartPersistentTunnel(
+      tunnelController,
+      readSettings().tunnelAutoReconnect,
+    ),
     close: async (): Promise<void> => {
       await tunnelController.shutdownForDesktopExit();
       logHub.stop();

--- a/apps/desktop/src/main/tunnel-controller.ts
+++ b/apps/desktop/src/main/tunnel-controller.ts
@@ -330,7 +330,11 @@ export class TunnelController {
           return this.statusFromRuntimeSnapshot(this.runtimeSnapshot, this.resolveClientPath());
         }
       }
-      if (this.state === 'running' || this.state === 'starting') return this.status();
+      // A status probe may have marked a surviving persistent runtime as
+      // running/external before Desktop has re-adopted the native alias. Only
+      // short-circuit for a process we actually own; otherwise continue into
+      // native reconciliation so update/restart can rebind the same Tunnel ID
+      // to the current Desktop MCP endpoint without spawning a duplicate.
       if (this.child !== null && this.child.exitCode === null) return this.status();
       const externalProbe = this.tunnelLock === null ? await this.probeExternalRunning(true) : 'gone';
       throwIfStartCancelled(signal);

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -29,6 +29,7 @@ import { FirstRunTunnelTip } from './features/onboarding/FirstRunTunnelTip.js';
 import {
   guidedTunnelLaunchDecision,
   guidedTunnelPrerequisiteSignature,
+  isTunnelConfigured,
   isTunnelRunning,
   readGuidedTunnelSetupState,
   writeGuidedTunnelSetupState,
@@ -206,7 +207,14 @@ export function App(): ReactElement {
     const signature = guidedTunnelPrerequisiteSignature(tunnel);
     if (guidedTunnelLaunchSignature.current === signature) return;
     guidedTunnelLaunchSignature.current = signature;
-    const state = readGuidedTunnelSetupState(window.localStorage);
+    let state = readGuidedTunnelSetupState(window.localStorage);
+    if (isTunnelConfigured(tunnel) && state !== 'completed') {
+      // Upgrades/reinstalls preserve the real tunnel prerequisites outside this
+      // renderer's localStorage. Normalize any stale onboarding marker so a
+      // previously configured user is never sent back to setup on next launch.
+      try { writeGuidedTunnelSetupState(window.localStorage, 'completed'); } catch { /* Real tunnel state remains authoritative. */ }
+      state = 'completed';
+    }
     const decision = guidedTunnelLaunchDecision(tunnel, state);
     if (decision === 'show_tip') {
       setFirstRunTunnelTipOpen(true);

--- a/apps/desktop/src/renderer/features/onboarding/guided-tunnel-setup-state.ts
+++ b/apps/desktop/src/renderer/features/onboarding/guided-tunnel-setup-state.ts
@@ -22,15 +22,16 @@ export function isTunnelConfigured(tunnel: TunnelStatus): boolean {
 }
 
 export function isTunnelRunning(tunnel: TunnelStatus): boolean {
-  return isTunnelConfigured(tunnel) && tunnel.state === 'running' && tunnel.source === 'desktop';
+  // A managed persistent runtime intentionally survives Desktop restarts and
+  // installer/update handoffs. During that detached window TunnelController may
+  // report source=external even though this is the same configured lnwjud tunnel.
+  // Runtime usability is therefore defined by the saved prerequisites + live
+  // state, not by which process currently owns the child handle.
+  return isTunnelConfigured(tunnel) && tunnel.state === 'running';
 }
 
 export function guidedTunnelPrerequisiteSignature(tunnel: TunnelStatus): string {
-  const runtime = isTunnelRunning(tunnel)
-    ? 'desktop-running'
-    : tunnel.source === 'external' && tunnel.state === 'running'
-      ? 'external-running'
-      : 'not-running';
+  const runtime = isTunnelRunning(tunnel) ? 'running' : 'not-running';
   return `${tunnel.hasApiKey ? 'key' : 'no-key'}:${tunnel.profileExists ? 'profile' : 'no-profile'}:${runtime}`;
 }
 
@@ -38,9 +39,12 @@ export function guidedTunnelLaunchDecision(
   tunnel: TunnelStatus,
   state: GuidedTunnelSetupState,
 ): GuidedTunnelLaunchDecision {
-  if (isTunnelRunning(tunnel)) return 'none';
+  // Existing configured users must never be redirected back into onboarding on
+  // update/reinstall/restart. The persistent runtime may still be reconciling for
+  // a moment, but the saved Tunnel ID/profile + DPAPI key are already sufficient.
+  if (isTunnelConfigured(tunnel)) return 'none';
   if (state === 'dismissed') return isFreshTunnelSetup(tunnel) ? 'none' : 'resume_settings';
-  if (state === 'completed') return isFreshTunnelSetup(tunnel) ? 'show_tip' : isTunnelConfigured(tunnel) ? 'none' : 'resume_settings';
+  if (state === 'completed') return isFreshTunnelSetup(tunnel) ? 'show_tip' : 'resume_settings';
   if (state === 'in_progress') return 'resume_settings';
   return isFreshTunnelSetup(tunnel) ? 'show_tip' : 'resume_settings';
 }

--- a/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
@@ -410,7 +410,7 @@ export function SettingsPage(props: SettingsPageProps): ReactElement {
             <>
               <section className="panel settings-card settings-card-polished guided-tunnel-launch-card" aria-label={t('guidedTunnel.openGuide')}>
                 <SettingsCardHeading icon="↗" title={t('guidedTunnel.openGuide')} subtitle={t('guidedTunnel.privacy')} badge={guidedTunnelRunning ? 'RUNNING' : guidedTunnelConfigured ? 'READY' : 'SETUP'} />
-                <p className="hint">{guidedTunnelRunning ? t('guidedTunnel.localComplete') : t('guidedTunnel.dismissedHint')}</p>
+                <p className="hint">{guidedTunnelRunning ? t('guidedTunnel.localComplete') : guidedTunnelConfigured ? t('guidedTunnel.configured') : t('guidedTunnel.dismissedHint')}</p>
                 <button type="button" className="btn-save-gold" onClick={() => props.onGuidedTunnelSetupOpenChange(true)}>{t('guidedTunnel.openGuide')}</button>
               </section>
 

--- a/apps/desktop/tests/guided-tunnel-setup-state.test.ts
+++ b/apps/desktop/tests/guided-tunnel-setup-state.test.ts
@@ -66,9 +66,10 @@ describe('guided tunnel setup state', () => {
     expect(guidedTunnelLaunchDecision(pristineTunnel({ hasApiKey: true, profileExists: true }), 'completed')).toBe('none');
   });
 
-  it('resumes an in-progress setup until a desktop-owned configured tunnel reaches running', () => {
+  it('never reopens onboarding for an already configured tunnel, including a detached persistent runtime', () => {
     expect(guidedTunnelLaunchDecision(pristineTunnel(), 'in_progress')).toBe('resume_settings');
-    expect(guidedTunnelLaunchDecision(pristineTunnel({ state: 'running', source: 'external' }), 'in_progress')).toBe('resume_settings');
+    expect(guidedTunnelLaunchDecision(pristineTunnel({ hasApiKey: true, profileExists: true }), 'in_progress')).toBe('none');
+    expect(guidedTunnelLaunchDecision(pristineTunnel({ state: 'running', source: 'external', hasApiKey: true, profileExists: true }), 'in_progress')).toBe('none');
     expect(guidedTunnelLaunchDecision(pristineTunnel({ state: 'running', source: 'desktop', hasApiKey: true, profileExists: true }), 'in_progress')).toBe('none');
   });
 
@@ -78,7 +79,7 @@ describe('guided tunnel setup state', () => {
     expect(guidedTunnelLaunchDecision(pristineTunnel({ profileExists: true }), 'dismissed')).toBe('resume_settings');
   });
 
-  it('derives fresh, configured, and running states from real prerequisites and ownership', () => {
+  it('derives fresh, configured, and running states from real prerequisites without coupling to Desktop process ownership', () => {
     expect(isFreshTunnelSetup(pristineTunnel())).toBe(true);
     expect(isFreshTunnelSetup(pristineTunnel({ persistent: {
       enabled: true,
@@ -103,15 +104,15 @@ describe('guided tunnel setup state', () => {
     } }))).toBe(true);
     expect(isTunnelConfigured(pristineTunnel({ hasApiKey: true, profileExists: true }))).toBe(true);
     expect(isTunnelConfigured(pristineTunnel({ hasApiKey: true }))).toBe(false);
-    expect(isTunnelRunning(pristineTunnel({ state: 'running', source: 'external', hasApiKey: true, profileExists: true }))).toBe(false);
+    expect(isTunnelRunning(pristineTunnel({ state: 'running', source: 'external', hasApiKey: true, profileExists: true }))).toBe(true);
     expect(isTunnelRunning(pristineTunnel({ state: 'running', source: 'desktop', hasApiKey: true, profileExists: true }))).toBe(true);
   });
 
-  it('changes the launch signature only when real prerequisites or runtime ownership change', () => {
+  it('changes the launch signature only when real prerequisites or runtime liveness change', () => {
     expect(guidedTunnelPrerequisiteSignature(pristineTunnel())).toBe('no-key:no-profile:not-running');
     expect(guidedTunnelPrerequisiteSignature(pristineTunnel({ hasApiKey: true }))).toBe('key:no-profile:not-running');
-    expect(guidedTunnelPrerequisiteSignature(pristineTunnel({ hasApiKey: true, profileExists: true, state: 'running', source: 'external' }))).toBe('key:profile:external-running');
-    expect(guidedTunnelPrerequisiteSignature(pristineTunnel({ hasApiKey: true, profileExists: true, state: 'running', source: 'desktop' }))).toBe('key:profile:desktop-running');
+    expect(guidedTunnelPrerequisiteSignature(pristineTunnel({ hasApiKey: true, profileExists: true, state: 'running', source: 'external' }))).toBe('key:profile:running');
+    expect(guidedTunnelPrerequisiteSignature(pristineTunnel({ hasApiKey: true, profileExists: true, state: 'running', source: 'desktop' }))).toBe('key:profile:running');
   });
 
   it('resumes at the first step required by the actual tunnel state', () => {
@@ -119,7 +120,7 @@ describe('guided tunnel setup state', () => {
     expect(initialGuidedTunnelStep(pristineTunnel({ hasApiKey: true }))).toBe('create_tunnel');
     expect(initialGuidedTunnelStep(pristineTunnel({ profileExists: true }))).toBe('save_key');
     expect(initialGuidedTunnelStep(pristineTunnel({ hasApiKey: true, profileExists: true }))).toBe('start');
-    expect(initialGuidedTunnelStep(pristineTunnel({ hasApiKey: true, profileExists: true, state: 'running', source: 'external' }))).toBe('start');
+    expect(initialGuidedTunnelStep(pristineTunnel({ hasApiKey: true, profileExists: true, state: 'running', source: 'external' }))).toBe('connect_chatgpt');
     expect(initialGuidedTunnelStep(pristineTunnel({ hasApiKey: true, profileExists: true, state: 'running', source: 'desktop' }))).toBe('connect_chatgpt');
   });
 

--- a/apps/desktop/tests/guided-tunnel-setup-ui.test.ts
+++ b/apps/desktop/tests/guided-tunnel-setup-ui.test.ts
@@ -68,10 +68,12 @@ describe('guided tunnel onboarding UI', () => {
     expect(stale).not.toContain('Open ChatGPT Plugins');
   });
 
-  it('does not treat a configured externally-owned runtime as locally complete', () => {
+  it('treats a configured externally-observed persistent runtime as locally complete', () => {
     const external = guideMarkup('en', tunnel({ state: 'running', source: 'external', hasApiKey: true, profileExists: true }));
-    expect(external).toContain('4. Start the Tunnel');
-    expect(external).not.toContain('Local setup is complete.');
+    expect(external).toContain('Local setup is complete.');
+    expect(external).toContain('5. Connect in ChatGPT');
+    expect(external).toContain('Open ChatGPT Plugins');
+    expect(external).not.toContain('4. Start the Tunnel');
   });
 
   it('disables Start Tunnel until both the key and profile are ready', () => {

--- a/apps/desktop/tests/mutation-safety-ui.test.ts
+++ b/apps/desktop/tests/mutation-safety-ui.test.ts
@@ -97,13 +97,13 @@ function recoveryMarkup(locale: 'th' | 'en'): string {
 }
 
 describe('mutation safety UI contract', () => {
-  it('renders the actual 4.12.0 application version', () => {
-    expect(APP_VERSION).toBe('4.12.0');
+  it('renders the actual 4.12.1 application version', () => {
+    expect(APP_VERSION).toBe('4.12.1');
     const markup = renderToStaticMarkup(createElement(AppShell, {
       locale: 'en', appVersion: APP_VERSION, mcpRunning: false, updateStatus: null, screen: 'settings',
       onNavigate: () => undefined, onLocaleChange: () => undefined, onUpdateAction: () => undefined, children: createElement('div'),
     }));
-    expect(markup).toContain('v4.12.0');
+    expect(markup).toContain('v4.12.1');
   });
 
   it('renders all destructive auto-approval settings and keeps critical/recovery safeguards locked', () => {

--- a/apps/desktop/tests/tunnel-continuity-acceptance.test.ts
+++ b/apps/desktop/tests/tunnel-continuity-acceptance.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { TunnelStatus } from '@lnwjud/ipc-contracts';
+import { autoStartPersistentTunnel } from '../src/main/desktop-services.js';
 import { TunnelRuntimeReconciler, type TunnelRuntimeDesiredState, type TunnelRuntimeReconcilerAdapter } from '../src/main/tunnel-runtime-reconciler.js';
 import { TunnelRuntimeSupervisor, TRANSIENT_BACKOFF_MS } from '../src/main/tunnel-runtime-supervisor.js';
 import type { NativeRuntimeConnectRequest } from '../src/main/tunnel-runtime-adapter.js';
@@ -172,5 +174,48 @@ describe('v4.11 persistent tunnel continuity acceptance', () => {
       snapshot: { tunnelId: TUNNEL_ID, state: 'error', lastErrorCode: 'TUNNEL_ID_MISMATCH' },
     });
     expect(adapter.connectRequests).toHaveLength(0);
+  });
+
+  it('keeps a surviving tunnel untouched when startup prerequisites are temporarily unavailable during reinstall', async () => {
+    const baseStatus: TunnelStatus = {
+      state: 'running',
+      source: 'external',
+      hasApiKey: true,
+      clientPath: 'C:\\Program Files\\lnwjud\\resources\\tunnel-client\\tunnel-client.exe',
+      profileExists: true,
+      message: null,
+      logPath: 'C:\\Users\\fixture\\AppData\\Roaming\\tunnel-client\\lnwjud.log',
+      persistent: null,
+    };
+    const prerequisiteGaps: TunnelStatus[] = [
+      { ...baseStatus, hasApiKey: false },
+      { ...baseStatus, profileExists: false },
+      { ...baseStatus, clientPath: null },
+    ];
+
+    for (const status of prerequisiteGaps) {
+      const startAutomatically = vi.fn(async (): Promise<TunnelStatus> => status);
+      const controller = { status: vi.fn(async (): Promise<TunnelStatus> => status), startAutomatically };
+      await expect(autoStartPersistentTunnel(controller, true)).resolves.toBe(status);
+      expect(startAutomatically).not.toHaveBeenCalled();
+    }
+  });
+
+  it('does not stop or replace an already-observed tunnel when persistent auto reconnect is disabled at startup', async () => {
+    const status: TunnelStatus = {
+      state: 'running',
+      source: 'external',
+      hasApiKey: true,
+      clientPath: 'C:\\Program Files\\lnwjud\\resources\\tunnel-client\\tunnel-client.exe',
+      profileExists: true,
+      message: null,
+      logPath: 'C:\\Users\\fixture\\AppData\\Roaming\\tunnel-client\\lnwjud.log',
+      persistent: null,
+    };
+    const startAutomatically = vi.fn(async (): Promise<TunnelStatus> => status);
+    const controller = { status: vi.fn(async (): Promise<TunnelStatus> => status), startAutomatically };
+
+    await expect(autoStartPersistentTunnel(controller, false)).resolves.toBe(status);
+    expect(startAutomatically).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/tests/tunnel-controller.test.ts
+++ b/apps/desktop/tests/tunnel-controller.test.ts
@@ -62,6 +62,63 @@ describe('TunnelController lifecycle', () => {
     await expect(controller.startAutomatically()).resolves.toMatchObject({ state: 'stopped' });
   });
 
+  it('re-adopts a surviving native runtime after status first observes it as external', async () => {
+    const dataPath = await mkdtemp(path.join(os.tmpdir(), 'lnwjud-tunnel-restart-adopt-'));
+    temporaryRoots.push(dataPath);
+    const appData = path.join(dataPath, 'appdata');
+    vi.stubEnv('APPDATA', appData);
+    const profileDir = path.join(appData, 'tunnel-client');
+    await (await import('node:fs/promises')).mkdir(profileDir, { recursive: true });
+    await writeFile(path.join(profileDir, 'lnwjud.yaml'), JSON.stringify({
+      control_plane: { tunnel_id: 'tunnel_fixture012345' },
+      mcp: { server_urls: [{ channel: 'main', url: 'http://127.0.0.1:17654/mcp' }] },
+    }, null, 2), 'utf8');
+    await writeFile(path.join(profileDir, 'lnwjud.runtime.secret'), 'encrypted-fixture', 'utf8');
+    const clientPath = path.join(dataPath, 'tunnel-client.exe');
+    await writeFile(clientPath, 'fixture', 'utf8');
+    const capabilities: TunnelRuntimeCapabilities = {
+      clientVersion: 'fixture', nativeRuntimes: true, managedConnect: true, healthProbe: true,
+      pollHealthGate: true, readyBeforeRetire: false, strictZeroDowntime: false, evidence: 'fixture',
+    };
+    const status = vi.fn(async () => ({
+      exists: true, running: true, healthy: true, ready: true, pollHealthy: true,
+      tunnelId: 'tunnel_fixture012345', mcpServerUrl: 'http://127.0.0.1:17654/mcp', pid: 4321, uiUrl: null, message: null,
+    }));
+    const connect = vi.fn(async () => ({
+      exists: true, running: true, healthy: true, ready: true, pollHealthy: true,
+      tunnelId: 'tunnel_fixture012345', mcpServerUrl: 'http://127.0.0.1:18765/mcp', pid: 4321, uiUrl: null, message: null,
+    }));
+    const adapter: TunnelRuntimeReconcilerAdapter = {
+      runtimeAlias: (): string => 'lnwjud',
+      capabilities: vi.fn(async () => capabilities),
+      status,
+      connect,
+      stop: vi.fn(async () => { throw new Error('stop should not be called'); }),
+    };
+    const controller = new TunnelController({
+      getClientPath: (): string => clientPath,
+      setClientPath: (): void => undefined,
+      getDataPath: (): string => dataPath,
+      getMcpServerUrl: (): string => 'http://127.0.0.1:18765/mcp',
+      getTunnelId: (): string => 'tunnel_fixture012345',
+      setTunnelId: (): void => undefined,
+      createRuntimeAdapter: (): TunnelRuntimeReconcilerAdapter => adapter,
+      decryptSecret: async (): Promise<string> => 'runtime-key',
+      isExternalTunnelRunning: async (): Promise<boolean> => true,
+    });
+
+    await expect(controller.status()).resolves.toMatchObject({
+      state: 'running', source: 'external', persistent: { mode: 'external' },
+    });
+    await expect(controller.startAutomatically()).resolves.toMatchObject({
+      state: 'running', source: 'desktop', persistent: { mode: 'native-managed', localMcpUrl: 'http://127.0.0.1:18765/mcp' },
+    });
+    expect(connect).toHaveBeenCalledWith({
+      tunnelId: 'tunnel_fixture012345',
+      mcpServerUrl: 'http://127.0.0.1:18765/mcp',
+    });
+  });
+
   it('invalidates a cached external-live probe when the operator explicitly stops the tunnel', async () => {
     const dataPath = await mkdtemp(path.join(os.tmpdir(), 'lnwjud-tunnel-stop-cache-'));
     temporaryRoots.push(dataPath);

--- a/docs/USAGE_TH.md
+++ b/docs/USAGE_TH.md
@@ -1,8 +1,8 @@
-# คู่มือใช้งาน lnwjud v4.12.0 (ภาษาไทย)
+# คู่มือใช้งาน lnwjud v4.12.1 (ภาษาไทย)
 
 lnwjud คือ Windows-first local AI-agent runtime / MCP gateway สำหรับให้ ChatGPT, Codex และ MCP client อื่นทำงานกับเครื่อง Windows ของคุณ เช่น อ่าน/ค้น/แก้ไฟล์, Git, รันโปรเซส, Windows UI automation, WSL, Office และเครื่องมือพัฒนาอื่น ๆ โดยงานจริงยังทำบนเครื่องของคุณ
 
-> สำหรับผู้ใช้ Windows x64 ที่ใช้ `lnwjud-Setup-4.12.0.exe` หรือ `lnwjud-Portable-4.12.0.exe` **ไม่ต้องติดตั้ง Node.js และไม่ต้องดาวน์โหลด `tunnel-client.exe` เอง** ตัว release รวม private Node.js runtime และ official OpenAI `tunnel-client v0.0.12` มาให้แล้ว
+> สำหรับผู้ใช้ Windows x64 ที่ใช้ `lnwjud-Setup-4.12.1.exe` หรือ `lnwjud-Portable-4.12.1.exe` **ไม่ต้องติดตั้ง Node.js และไม่ต้องดาวน์โหลด `tunnel-client.exe` เอง** ตัว release รวม private Node.js runtime และ official OpenAI `tunnel-client v0.0.12` มาให้แล้ว
 
 ---
 
@@ -15,7 +15,7 @@ lnwjud คือ Windows-first local AI-agent runtime / MCP gateway สำหร
 สำหรับ v4.11.0 ตัวโปรแกรมแยก compatibility profile ตามระบบ: Windows 10 x64 ใช้ software rendering เป็นค่าเริ่มต้นเพื่อลดปัญหาหน้าจอ Electron/Chromium ค้าง, วาดไม่ครบ หรือบาง control กดไม่ได้บน GPU/driver รุ่นเก่า ส่วน Windows 11 x64 ยังใช้ hardware acceleration ตามปกติ
 
 งานภายในโปรแกรมที่ต้องเรียก PowerShell ใช้ `powershell.exe` ที่มากับ Windows ไม่บังคับให้ติดตั้ง PowerShell 7 และ child process ภายในถูกเปิดแบบซ่อนหน้าต่าง console. ระบบยังจำกัด durable background task พร้อมกันไว้ 16 งาน และ managed process พร้อมกันไว้ 24 งาน เพื่อกันกรณีหลายแชทสั่งงานพร้อมกันจนเกิด `conhost.exe` จำนวนมาก/CPU เต็ม
-- `lnwjud-Setup-4.12.0.exe` หรือ `lnwjud-Portable-4.12.0.exe`
+- `lnwjud-Setup-4.12.1.exe` หรือ `lnwjud-Portable-4.12.1.exe`
 - OpenAI Platform tunnel ที่ผูกกับ ChatGPT workspace ที่จะใช้
 - Runtime API key ที่มีสิทธิ์ **Tunnels Read + Use**
 - อินเทอร์เน็ตขาออก HTTPS สำหรับ Secure MCP Tunnel
@@ -35,7 +35,7 @@ Node.js, pnpm และ Git จำเป็นเฉพาะกรณีพั�
 
 ### แบบแนะนำ: Installer
 
-1. ดาวน์โหลด `lnwjud-Setup-4.12.0.exe` จาก GitHub Releases
+1. ดาวน์โหลด `lnwjud-Setup-4.12.1.exe` จาก GitHub Releases
 2. ติดตั้งตามปกติ
 3. เปิด **lnwjud Agent Control Center**
 4. เพิ่ม Project/Workspace ที่ต้องการใช้งาน
@@ -43,7 +43,7 @@ Node.js, pnpm และ Git จำเป็นเฉพาะกรณีพั�
 
 ### แบบไม่ต้องติดตั้ง: Portable EXE
 
-1. ดาวน์โหลด `lnwjud-Portable-4.12.0.exe`
+1. ดาวน์โหลด `lnwjud-Portable-4.12.1.exe`
 2. วางไว้ในโฟลเดอร์ที่ต้องการแล้วเปิดไฟล์ได้ทันที ไม่ต้องรัน installer
 3. เพิ่ม Project/Workspace และตั้ง Tunnel เหมือนเวอร์ชันติดตั้ง
 
@@ -263,8 +263,8 @@ corepack pnpm@10.15.0 package:windows
 ไฟล์ที่ได้จะอยู่ที่:
 
 ```text
-apps/desktop/dist/installers/lnwjud-Setup-4.12.0.exe
-apps/desktop/dist/installers/lnwjud-Portable-4.12.0.exe
+apps/desktop/dist/installers/lnwjud-Setup-4.12.1.exe
+apps/desktop/dist/installers/lnwjud-Portable-4.12.1.exe
 apps/desktop/dist/installers/latest.yml
 apps/desktop/dist/installers/portable.yml
 ```

--- a/docs/development/PACKAGING_WINDOWS.md
+++ b/docs/development/PACKAGING_WINDOWS.md
@@ -27,7 +27,7 @@ The package script rebuilds the workspace, generates the current MCP stdio bundl
 
 ## Current electron-builder contract
 
-`apps/desktop/electron-builder.yml` is the source of truth. The current v4.12.0 packaging contract is:
+`apps/desktop/electron-builder.yml` is the source of truth. The current v4.12.1 packaging contract is:
 
 - `asar: true`.
 - Windows x64 targets: NSIS installer + portable executable.
@@ -69,12 +69,12 @@ The `makeappx.exe`/`signtool.exe` steps need the Windows SDK. No certificate or 
 
 ## Expected Windows outputs
 
-For v4.12.0:
+For v4.12.1:
 
 ```text
-apps/desktop/dist/installers/lnwjud-Setup-4.12.0.exe
-apps/desktop/dist/installers/lnwjud-Setup-4.12.0.exe.blockmap
-apps/desktop/dist/installers/lnwjud-Portable-4.12.0.exe
+apps/desktop/dist/installers/lnwjud-Setup-4.12.1.exe
+apps/desktop/dist/installers/lnwjud-Setup-4.12.1.exe.blockmap
+apps/desktop/dist/installers/lnwjud-Portable-4.12.1.exe
 apps/desktop/dist/installers/latest.yml
 apps/desktop/dist/installers/portable.yml
 apps/desktop/dist/installers/SHA256SUMS.txt

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lnwjud",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "engines": {

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/application",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/audit",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/capabilities/package.json
+++ b/packages/capabilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/capabilities",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/codex/package.json
+++ b/packages/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/codex",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/domain",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/extensions",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/filesystem",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/git",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ipc-contracts/package.json
+++ b/packages/ipc-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/ipc-contracts",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ipc-contracts/src/index.ts
+++ b/packages/ipc-contracts/src/index.ts
@@ -1,5 +1,5 @@
 export const APP_NAME = 'lnwjud';
-export const APP_VERSION = '4.12.0';
+export const APP_VERSION = '4.12.1';
 
 export const ipcChannels = {
   listWorkspaces: 'lnwjud:list-workspaces',

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/mcp-server",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/permissions",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/process",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/project",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/search",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/shared",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,5 @@
 export const APP_NAME = 'lnwjud';
-export const APP_VERSION = '4.12.0';
+export const APP_VERSION = '4.12.1';
 export { isUnrestricted, unrestrictedFromEnv, unrestrictedFromSetting, UNRESTRICTED_SETTING_KEY, type ProcessEnvLike } from './unrestricted.js';
 
 export { resolveLnwjudDataPath, type DataPathEnvironment } from './data-path.js';

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/storage",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/workspace",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -86,7 +86,21 @@ async function syncAllVersions() {
     // skip if missing
   }
 
-  // 7. Update README.md current-version references without rewriting release history.
+  // 7. Update Desktop UI version assertion.
+  const mutationSafetyUiTestPath = path.join(rootDir, 'apps', 'desktop', 'tests', 'mutation-safety-ui.test.ts');
+  try {
+    let testContent = await readFile(mutationSafetyUiTestPath, 'utf8');
+    testContent = testContent
+      .replace(/renders the actual [0-9.]+ application version/g, `renders the actual ${version} application version`)
+      .replace(/expect\(APP_VERSION\)\.toBe\(['"][^'"]+['"]\);/g, `expect(APP_VERSION).toBe('${version}');`)
+      .replace(/expect\(markup\)\.toContain\(['"]v[0-9.]+['"]\);/g, `expect(markup).toContain('v${version}');`);
+    await writeFile(mutationSafetyUiTestPath, testContent, 'utf8');
+    console.log(`Updated apps/desktop/tests/mutation-safety-ui.test.ts -> v${version}`);
+  } catch {
+    // skip if missing
+  }
+
+  // 8. Update README.md current-version references without rewriting release history.
   const readmePath = path.join(rootDir, 'README.md');
   try {
     let readmeContent = await readFile(readmePath, 'utf8');
@@ -96,6 +110,10 @@ async function syncAllVersions() {
       .replace(/current source\/release candidate is `v[0-9.]+`/g, 'current version is `v' + version + '`')
       .replace(/The Windows installer for the current version is `lnwjud-Setup-[0-9.]+\.exe`/g, 'The Windows installer for the current version is `lnwjud-Setup-' + version + '.exe`')
       .replace(/Current Windows 10\/11 x64 artifacts are `lnwjud-Setup-[0-9.]+\.exe` \(recommended installer\) and `lnwjud-Portable-[0-9.]+\.exe`/g, 'Current Windows 10/11 x64 artifacts are `lnwjud-Setup-' + version + '.exe` (recommended installer) and `lnwjud-Portable-' + version + '.exe`')
+      .replace(/If you prefer not to install the app, run `lnwjud-Portable-[0-9.]+\.exe` directly\./g, 'If you prefer not to install the app, run `lnwjud-Portable-' + version + '.exe` directly.')
+      .replace(/1\. แบบแนะนำ: ดาวน์โหลด `lnwjud-Setup-[0-9.]+\.exe` แล้วติดตั้งตามปกติ/g, '1. แบบแนะนำ: ดาวน์โหลด `lnwjud-Setup-' + version + '.exe` แล้วติดตั้งตามปกติ')
+      .replace(/2\. ถ้าไม่ต้องการติดตั้ง: ดาวน์โหลด `lnwjud-Portable-[0-9.]+\.exe` แล้วเปิดได้ทันที/g, '2. ถ้าไม่ต้องการติดตั้ง: ดาวน์โหลด `lnwjud-Portable-' + version + '.exe` แล้วเปิดได้ทันที')
+      .replace(/ถ้าใช้ `lnwjud-Setup-[0-9.]+\.exe` หรือ `lnwjud-Portable-[0-9.]+\.exe` บน Windows x64/g, 'ถ้าใช้ `lnwjud-Setup-' + version + '.exe` หรือ `lnwjud-Portable-' + version + '.exe` บน Windows x64')
       .replace(/single-file \*\*`lnwjud-Portable-[0-9.]+\.exe`\*\*/g, 'single-file **`lnwjud-Portable-' + version + '.exe`**')
       .replace(/validated local test installer `lnwjud-Setup-[0-9.]+\.exe`/g, 'validated local test installer `lnwjud-Setup-' + version + '.exe`')
       .replace(/apps\/desktop\/dist\/installers\/lnwjud-Setup-[0-9.]+\.exe/g, 'apps/desktop/dist/installers/lnwjud-Setup-' + version + '.exe')
@@ -109,7 +127,7 @@ async function syncAllVersions() {
     // skip if missing
   }
 
-  // 8. Update current-version Markdown references without rewriting release history.
+  // 9. Update current-version Markdown references without rewriting release history.
   const markdownTargets = [
     ['.github/RELEASE_CHECKLIST.md', (content) => content
       .replace(/\*\*Current (?:version|release candidate):\*\* `v[0-9.]+`/g, `**Current version:** ` + '`v' + version + '`')
@@ -121,6 +139,7 @@ async function syncAllVersions() {
       .replace(/lnwjud-Portable-[0-9.]+\.exe/g, `lnwjud-Portable-${version}.exe`)],
     ['docs/development/PACKAGING_WINDOWS.md', (content) => content
       .replace(/For v[0-9.]+:/g, `For v${version}:`)
+      .replace(/current v[0-9.]+ packaging contract/g, `current v${version} packaging contract`)
       .replace(/lnwjud-Setup-[0-9.]+\.exe/g, `lnwjud-Setup-${version}.exe`)
       .replace(/lnwjud-Portable-[0-9.]+\.exe/g, `lnwjud-Portable-${version}.exe`)],
     ['docs/LNWJUD_CAPABILITIES.md', (content) => content.replace(/lnwjud v[0-9.]+/g, `lnwjud v${version}`)],

--- a/tests/packaging/desktop-packaging.test.ts
+++ b/tests/packaging/desktop-packaging.test.ts
@@ -8,11 +8,11 @@ const desktopRoot = path.resolve(import.meta.dirname, '..', '..', 'apps', 'deskt
 const repositoryRoot = path.resolve(desktopRoot, '..', '..');
 
 describe('Windows desktop packaging', () => {
-  it('pins the product release to v4.12.0', async () => {
+  it('pins the product release to v4.12.1', async () => {
     const rootPackage = JSON.parse(await readFile(path.join(repositoryRoot, 'package.json'), 'utf8')) as { version?: unknown };
     const desktopPackage = JSON.parse(await readFile(path.join(desktopRoot, 'package.json'), 'utf8')) as { version?: unknown };
-    expect(rootPackage.version).toBe('4.12.0');
-    expect(desktopPackage.version).toBe('4.12.0');
+    expect(rootPackage.version).toBe('4.12.1');
+    expect(desktopPackage.version).toBe('4.12.1');
   });
 
   it('publishes complete desktop application metadata', async () => {


### PR DESCRIPTION
## Summary
- preserve the existing persistent Tunnel ID/profile/key across update, reinstall, and restart
- re-adopt a surviving native runtime when Desktop first observes it as external
- rebind the same tunnel to the current Desktop MCP endpoint without spawning a duplicate
- keep v4.12.0 feature notes and document v4.12.1 separately as a hotfix

## Verification
- focused tunnel-controller tests: 36/36 passed
- lint passed
- typecheck passed
- full test:release passed
- git diff --check passed