### PR TITLE
fix(release): stage bridge integrity before evidence check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,10 @@ jobs:
           }
           Write-Host "Using verified CI artifact from run $($run.databaseId) for commit $sha"
 
+      - name: Prepare capability bridge integrity evidence
+        shell: pwsh
+        run: node apps/desktop/scripts/write-capability-integrity.mjs
+
       - name: Verify source provenance and SHA-256 evidence
         shell: pwsh
         env:

--- a/tests/release/release-gate.test.ts
+++ b/tests/release/release-gate.test.ts
@@ -140,6 +140,10 @@ describe('MVP release verification gate', () => {
     expect(release).toContain('windows-release-$sha');
     expect(release).toContain('successful CI run for exact commit');
     expect(release).toContain('lnwjud-Portable-$($package.version).exe');
+    expect(release).toContain('Prepare capability bridge integrity evidence');
+    expect(release).toContain('node apps/desktop/scripts/write-capability-integrity.mjs');
+    expect(release.indexOf('Download verified CI artifact')).toBeLessThan(release.indexOf('Prepare capability bridge integrity evidence'));
+    expect(release.indexOf('Prepare capability bridge integrity evidence')).toBeLessThan(release.indexOf('Verify source provenance and SHA-256 evidence'));
     expect(release).not.toContain('verify-release.ps1');
     expect(release).toContain('apps/desktop/dist/installers/latest.yml');
     expect(release).toContain('apps/desktop/dist/installers/portable.yml');


### PR DESCRIPTION
Fixes the failed v4.44.0 Release workflow run 33388675733.\n\nThe release job downloads the exact verified Windows artifact, then verifies its provenance against source files. The verifier also requires the source-derived capability bridge staging files, which are build outputs and are not present in a fresh tag checkout.\n\nThis adds a bounded preparation step that runs write-capability-integrity.mjs immediately after artifact download and before verify-release-evidence.mjs. A release-gate regression test asserts the required order.\n\nLocal verification: release-gate tests 22/22 passed; the full local release gate and Windows packaging had already passed on the preceding fix.\n\nFailed workflow: https://github.com/engasnm111/lnwjud/actions/runs/33388675733