### PR TITLE
fix(release): skip unavailable packaged files in artifact mode

### DIFF
--- a/apps/desktop/scripts/verify-release-evidence.mjs
+++ b/apps/desktop/scripts/verify-release-evidence.mjs
@@ -25,20 +25,25 @@ if (process.env.LNWJUD_REQUIRE_CLEAN_PROVENANCE === '1' && provenance.source.dir
   throw new Error('Public release provenance must be built from a clean tracked source tree');
 }
 
-// The main CI package gate verifies the compiled bundle before uploading the
-// release artifact. The release job intentionally downloads only public
-// installers/evidence, so its artifact-only mode must not require build output.
-const compiledBundlePath = process.env.LNWJUD_RELEASE_ARTIFACT_ONLY === '1'
+// The main CI package gate verifies the compiled bundle and packaged bridge
+// before uploading the release artifact. The release job intentionally
+// downloads only public installers/evidence, so its artifact-only mode must
+// not require either build output.
+const releaseArtifactOnly = process.env.LNWJUD_RELEASE_ARTIFACT_ONLY === '1';
+const packagedBridgePath = releaseArtifactOnly
+  ? undefined
+  : path.join(installerDirectory, 'win-unpacked', 'resources', 'windows-capability-bridge.ps1');
+const compiledBundlePath = releaseArtifactOnly
   ? undefined
   : path.join(desktopRoot, 'dist', 'main', 'main.js');
 const verifiedCapabilityBridge = await verifyCapabilityBridgeArtifacts({
-  packagedBridgePath: path.join(installerDirectory, 'win-unpacked', 'resources', 'windows-capability-bridge.ps1'),
+  packagedBridgePath,
   compiledBundlePath,
 });
 if (!isCapabilityBridgeIdentity(provenance.capabilityBridge)
   || provenance.capabilityBridge.sha256 !== verifiedCapabilityBridge.sha256
   || provenance.capabilityBridge.sizeBytes !== verifiedCapabilityBridge.sizeBytes) {
-  throw new Error('Provenance capability bridge identity does not match verified packaged bytes');
+  throw new Error('Provenance capability bridge identity does not match verified bridge bytes');
 }
 
 if (!Array.isArray(provenance.artifacts) || provenance.artifacts.length < 5) throw new Error('Provenance artifact list is incomplete');

--- a/tests/packaging/windows-trust-evidence.test.ts
+++ b/tests/packaging/windows-trust-evidence.test.ts
@@ -38,7 +38,9 @@ describe('Windows release trust evidence', () => {
     expect(evidenceWriter).toContain("git(['rev-parse', 'HEAD'])");
     expect(evidenceWriter).toContain('capabilityBridge');
     expect(evidenceVerifier).toContain('LNWJUD_RELEASE_ARTIFACT_ONLY');
+    expect(evidenceVerifier).toMatch(/const packagedBridgePath = releaseArtifactOnly\s+\? undefined\s+: path\.join\(installerDirectory, 'win-unpacked'/);
     expect(evidenceVerifier).toContain('compiledBundlePath');
+    expect(evidenceVerifier).toContain('const releaseArtifactOnly');
     expect(evidenceVerifier).toContain('verifyCapabilityBridgeArtifacts');
     expect(bridgeVerifier).toContain('packaged bridge bytes differ from staged package bytes');
     for (const name of ['lnwjud-mcp-stdio.cjs', 'lnwjud-node.exe', 'windows-capability-bridge.ps1', 'windows-capability-bridge.sha256', 'windows-capability-bridge.integrity.json', 'rg.exe', 'tunnel-client.exe']) {

--- a/tests/release/release-gate.test.ts
+++ b/tests/release/release-gate.test.ts
@@ -143,6 +143,7 @@ describe('MVP release verification gate', () => {
     expect(release).toContain('Prepare capability bridge integrity evidence');
     expect(release).toContain('node apps/desktop/scripts/write-capability-integrity.mjs');
     expect(release).toContain("LNWJUD_RELEASE_ARTIFACT_ONLY: '1'");
+    expect(release).toContain('apps/desktop/dist/installers/PROVENANCE.json');
     expect(release.indexOf('Download verified CI artifact')).toBeLessThan(release.indexOf('Prepare capability bridge integrity evidence'));
     expect(release.indexOf('Prepare capability bridge integrity evidence')).toBeLessThan(release.indexOf('Verify source provenance and SHA-256 evidence'));
     expect(release).not.toContain('verify-release.ps1');


### PR DESCRIPTION
The release job downloads only the public installer/evidence files from the exact-main CI artifact. In artifact-only mode, skip local win-unpacked and compiled-bundle paths while retaining those checks in the main packaging gate. Add regression coverage for the mode split and keep the release workflow contract explicit.