### PR TITLE
fix: stabilize v4.45.0 release CI

### DIFF
--- a/tests/integration/codex-review-flow.test.ts
+++ b/tests/integration/codex-review-flow.test.ts
@@ -164,8 +164,9 @@ function fakeCodexSource(): string {
     "import { writeFile } from 'node:fs/promises';",
     "import path from 'node:path';",
     "process.stdout.write('fake-codex-started\\n');",
-    "await writeFile(path.join(process.cwd(), 'src', 'reviewed.ts'), 'export const reviewed = true;\\n', 'utf8');",
-    "if (process.argv[2]?.includes('hold')) await new Promise(() => { setInterval(() => {}, 1000); });",
+    "const hold = process.argv[2]?.includes('hold');",
+    "if (!hold) await writeFile(path.join(process.cwd(), 'src', 'reviewed.ts'), 'export const reviewed = true;\\n', 'utf8');",
+    "if (hold) await new Promise(() => { setInterval(() => {}, 1000); });",
   ].join('\n');
 }
 


### PR DESCRIPTION
## Summary
- avoid mutating the review fixture during Codex stop-verification
- remove the Windows CI race that could leave reviewed.ts empty when the fake process is killed mid-write

## Verification
- focused codex-review-flow integration test passes locally
- this PR intentionally does not package Windows artifacts; authoritative packaging remains on main CI
