### PR TITLE
fix: stabilize application CI timeouts

### DIFF
--- a/packages/application/vitest.config.ts
+++ b/packages/application/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    testTimeout: process.env.CI ? 20_000 : 5_000,
+    hookTimeout: process.env.CI ? 20_000 : 10_000,
+  },
+});


### PR DESCRIPTION
## Summary
- add an application-package Vitest config with CI-only 20s test/hook timeouts
- keep local test timeout behavior unchanged at 5s
- align application tests with the existing storage/desktop CI timeout policy

## Why
The exact-main v4.45.0 CI hit three unrelated 5s timeouts on the GitHub Windows runner after the prior race fix, while the same application suite passes locally. This keeps production code unchanged and gives CI the same bounded headroom already used by other packages.

## Verification
- `CI=true corepack pnpm@10.15.0 --filter @lnwjud/application test`
- 25 files / 160 tests passed
- PR CI should use `-SkipWindowsPackaging`; authoritative packaging remains on main
