### PR TITLE
fix(release): select bundle checksums beside provenance

### DIFF
--- a/scripts/collect-release-assets.mjs
+++ b/scripts/collect-release-assets.mjs
@@ -32,7 +32,11 @@ for (const target of targets) {
   const targetDirectory = path.join(stagingDirectory, target.key);
   await assertRegularDirectory(targetDirectory, `Staged ${target.key} artifact`);
   const provenancePath = await findUniqueFile(targetDirectory, 'PROVENANCE.json');
-  const sumsPath = await findUniqueFile(targetDirectory, 'SHA256SUMS.txt');
+  // CI also uploads unpacked apps whose dependencies have their own checksums.
+  // Only the files beside the unique release provenance belong to this bundle.
+  const installerDirectory = path.dirname(provenancePath);
+  const sumsPath = path.join(installerDirectory, 'SHA256SUMS.txt');
+  await assertRegularFile(sumsPath, 'Release checksums');
   const provenance = JSON.parse(await readFile(provenancePath, 'utf8'));
   const sumsText = await readFile(sumsPath, 'utf8');
   const sums = parseSums(sumsText);
@@ -41,7 +45,8 @@ for (const target of targets) {
   const artifactNames = expectedArtifactNames(target.platform, version, target.arch);
   const sourceArtifacts = [];
   for (const artifactName of artifactNames) {
-    const artifactPath = await findUniqueFile(targetDirectory, artifactName);
+    const artifactPath = path.join(installerDirectory, artifactName);
+    await assertRegularFile(artifactPath, artifactName);
     const provenanceEntry = provenance.artifacts?.find((entry) => entry?.name === artifactName);
     if (!provenanceEntry) throw new Error(`${target.key} provenance is missing ${artifactName}`);
     const actualHash = await sha256File(artifactPath);

--- a/tests/release/release-asset-collector.test.ts
+++ b/tests/release/release-asset-collector.test.ts
@@ -12,7 +12,7 @@ const version = '4.56.0';
 const commit = '0123456789abcdef0123456789abcdef01234567';
 
 describe('release asset collector', () => {
-  it('validates all target evidence and creates architecture-aware public assets', async () => {
+  it('validates target evidence beside provenance without confusing bundled dependency checksums', async () => {
     // Windows hosted runners may expose TEMP through a DOS short-name alias;
     // the collector intentionally requires canonical staging paths.
     const temporaryRoot = await realpath(await mkdtemp(path.join(os.tmpdir(), 'lnwjud-release-collector-')));
@@ -27,6 +27,9 @@ describe('release asset collector', () => {
         { key: 'linux-arm64', platform: 'linux', arch: 'arm64' },
       ]) {
         await writeTargetFixture(stagingDirectory, target);
+        const dependencyDirectory = path.join(stagingDirectory, target.key, 'apps', 'desktop', 'dist', 'installers', 'unpacked', 'dependency');
+        await mkdir(dependencyDirectory, { recursive: true });
+        await writeFile(path.join(dependencyDirectory, 'SHA256SUMS.txt'), 'unrelated dependency checksums\n');
       }
 
       await execFileAsync(process.execPath, [path.join(repositoryRoot, 'scripts', 'collect-release-assets.mjs')], {
@@ -80,6 +83,31 @@ describe('release asset collector', () => {
       };
       expect(releaseManifest.sourceCommit).toBe(commit);
       expect(releaseManifest.targets).toHaveLength(5);
+    } finally {
+      await rm(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a missing sibling checksum instead of using a nested copy', async () => {
+    const temporaryRoot = await realpath(await mkdtemp(path.join(os.tmpdir(), 'lnwjud-release-collector-')));
+    const stagingDirectory = path.join(temporaryRoot, 'staging');
+    try {
+      await writeTargetFixture(stagingDirectory, { key: 'win32-x64', platform: 'win32', arch: 'x64' });
+      const installerDirectory = path.join(stagingDirectory, 'win32-x64', 'apps', 'desktop', 'dist', 'installers');
+      const sums = await readFile(path.join(installerDirectory, 'SHA256SUMS.txt'));
+      await mkdir(path.join(installerDirectory, 'nested'));
+      await writeFile(path.join(installerDirectory, 'nested', 'SHA256SUMS.txt'), sums);
+      await rm(path.join(installerDirectory, 'SHA256SUMS.txt'));
+      await expect(execFileAsync(process.execPath, [path.join(repositoryRoot, 'scripts', 'collect-release-assets.mjs')], {
+        cwd: repositoryRoot,
+        env: {
+          ...process.env,
+          LNWJUD_RELEASE_STAGING_DIRECTORY: stagingDirectory,
+          LNWJUD_RELEASE_ASSETS_DIRECTORY: path.join(temporaryRoot, 'assets'),
+          LNWJUD_RELEASE_COMMIT: commit,
+        },
+        windowsHide: true,
+      })).rejects.toThrow(/ENOENT.*SHA256SUMS\.txt/s);
     } finally {
       await rm(temporaryRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
Fix the release collector to read checksums and payloads beside the unique release provenance, rather than confusing bundled dependency SHA256SUMS.txt files with release evidence. Reproduced against exact-main CI artifacts for b8a2e93; added positive duplicate-dependency and negative missing-sibling regression tests. Release tests 16 passed, targeted lint passed. Runtime application code is unchanged. Rebuild and verify the new exact main commit before tagging v4.56.0.