### PR TITLE
fix: v4.56.1 Windows legacy-secret startup hotfix

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -2,7 +2,7 @@
 
 Operational release sequencing is defined by [`docs/development/RELEASE_PROCESS.md`](../docs/development/RELEASE_PROCESS.md). This checklist records current-version acceptance evidence and does not override that sequence.
 
-**Current version:** `v4.56.0` - Windows installer `lnwjud-Setup-4.56.0.exe` and portable executable `lnwjud-Portable-4.56.0.exe`; MCP registry **232 total definitions / 225 advertised by default / all 232 with Codex delegation plus Agent Swarm enabled**.
+**Current version:** `v4.56.1` - Windows installer `lnwjud-Setup-4.56.1.exe` and portable executable `lnwjud-Portable-4.56.1.exe`; MCP registry **232 total definitions / 225 advertised by default / all 232 with Codex delegation plus Agent Swarm enabled**.
 
 Run the release verification from PowerShell at the repository root. The automated gate must fail fast on any non-zero stage and `git diff --check` must pass before packaging or publishing. Pull-request/non-main CI may pass `-SkipWindowsPackaging`; the exact `main` commit that will be tagged must run the full Windows gate plus the target-native macOS/Linux package matrix and produce all five SHA-scoped release artifacts.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,12 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
         run: powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/verify-release.ps1
 
+      - name: Verify packaged Windows legacy-profile startup
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          LNWJUD_PACKAGED_EXECUTABLE: ${{ github.workspace }}/apps/desktop/dist/installers/win-unpacked/lnwjud.exe
+        run: corepack pnpm@10.15.0 --filter @lnwjud/desktop exec playwright test --config playwright.config.ts --grep "Windows upgrade opens"
+
       - name: Upload Windows E2E diagnostics
         if: failure()
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -43,14 +43,21 @@ The tunnel is outbound-only: `tunnel-client` runs beside lnwjud, reaches OpenAI
 over outbound HTTPS, forwards MCP work to lnwjud's Desktop loopback HTTP MCP,
 and returns the response without opening a public inbound port on the host.
 
-## Current version: v4.56.0
+## Current version: v4.56.1
 
-The v4.56.0 release target and runtime contract contain **232 total MCP tool definitions**,
+The v4.56.1 release target and runtime contract contain **232 total MCP tool definitions**,
 with **225 advertised by default** and **all 232 advertised when the six `codex_*`
 delegation tools plus the bounded read-only `agent_swarm_run` tool are enabled**. The seven Codex/Agent Swarm definitions are opt-in;
 the default surface still exposes every other current first-party definition. The earlier 184-tool snapshot remains
 only as the compatibility baseline used by the v4 architecture; new v4 gateway
 capabilities are additive.
+
+### What's new in v4.56.1
+
+- Fixes Windows startup after upgrading a profile with legacy DPAPI/SecureString secrets: the native migrator now reads the checksum filename actually shipped in the installer.
+- Preserves integrity verification, existing encrypted data, and migration backups. Adds native-helper and real legacy-profile startup regression tests.
+- Keeps macOS/Linux on the shared release version; Windows migration remains a no-op on those platforms.
+- If v4.56.0 cannot open to update itself, install v4.56.1 manually over the existing installation. Do not delete the profile or secret files. A narrowly scoped v4.56.0 recovery script is available at `scripts/repair-windows-4.56.0-startup.ps1`.
 
 ### What's new in v4.56.0
 
@@ -302,13 +309,13 @@ Choose the guide for the host you will run lnwjud on:
 
 1. Download the latest published installer from
    [GitHub Releases](https://github.com/engasnm111/lnwjud/releases/latest).
-   Current Windows 10/11 x64 artifacts are `lnwjud-Setup-4.56.0.exe` (recommended installer) and `lnwjud-Portable-4.56.0.exe` (no installation required).
+   Current Windows 10/11 x64 artifacts are `lnwjud-Setup-4.56.1.exe` (recommended installer) and `lnwjud-Portable-4.56.1.exe` (no installation required).
 2. Run the NSIS installer and launch **lnwjud Agent Control Center**.
 3. Add or select the project/workspace you want lnwjud to operate on.
 4. Review **Settings** before attaching an AI client, especially Permission
    Profile and Unrestricted Mode.
 
-If you prefer not to install the app, run `lnwjud-Portable-4.56.0.exe` directly.
+If you prefer not to install the app, run `lnwjud-Portable-4.56.1.exe` directly.
 Portable mode uses the same per-user lnwjud data/settings location as the installer;
 it is a portable executable, not a keep-all-data-next-to-the-EXE mode.
 Automatic updates preserve the distribution you chose. Installer users read
@@ -417,8 +424,8 @@ Use lnwjud to list registered workspaces, report Git status for the selected pro
 
 ### 1. ติดตั้ง lnwjud หรือใช้ Portable
 
-1. แบบแนะนำ: ดาวน์โหลด `lnwjud-Setup-4.56.0.exe` แล้วติดตั้งตามปกติ
-2. ถ้าไม่ต้องการติดตั้ง: ดาวน์โหลด `lnwjud-Portable-4.56.0.exe` แล้วเปิดได้ทันที
+1. แบบแนะนำ: ดาวน์โหลด `lnwjud-Setup-4.56.1.exe` แล้วติดตั้งตามปกติ
+2. ถ้าไม่ต้องการติดตั้ง: ดาวน์โหลด `lnwjud-Portable-4.56.1.exe` แล้วเปิดได้ทันที
 3. เปิด **lnwjud Agent Control Center**
 4. เพิ่มหรือเลือก Project/Workspace ที่ต้องการให้ ChatGPT ทำงานด้วย
 
@@ -697,8 +704,8 @@ corepack pnpm@10.15.0 package:windows
 The Windows 10/11 x64 artifacts are written to:
 
 ```text
-apps/desktop/dist/installers/lnwjud-Setup-4.56.0.exe
-apps/desktop/dist/installers/lnwjud-Portable-4.56.0.exe
+apps/desktop/dist/installers/lnwjud-Setup-4.56.1.exe
+apps/desktop/dist/installers/lnwjud-Portable-4.56.1.exe
 ```
 
 The installer is per-user by default. The portable executable needs no installation but uses the same per-user lnwjud data/settings location. A common installed executable path is:

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/cli",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/apps/desktop/e2e/tools-doctor.e2e.ts
+++ b/apps/desktop/e2e/tools-doctor.e2e.ts
@@ -1,5 +1,7 @@
-import { access, copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { spawn, type ChildProcess } from 'node:child_process';
+import { access, copyFile, mkdir, mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
+import { spawn, execFile, type ChildProcess } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync } from 'node:fs';
 import { createServer } from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
@@ -23,6 +25,19 @@ type LaunchedDesktop = {
 
 test.describe('Tools catalog and Doctor real Electron acceptance', () => {
   test.setTimeout(120_000);
+
+  test('Windows upgrade opens with a real legacy checkpoint and retains its backup', async () => {
+    test.setTimeout(180_000); // Includes first-run native helper fixture compilation in source mode.
+    test.skip(process.platform !== 'win32', 'Windows DPAPI upgrade acceptance');
+    const app = await launchDesktop({ legacyCheckpoint: true });
+    try {
+      await openTools(app.page);
+      await expect(app.page.locator('.tool-card')).toHaveCount(232);
+      expect(await readFile(path.join(app.dataRoot, 'checkpoint-master.key'), 'utf8')).toMatch(/^safe:v1:/);
+      expect(await readFile(path.join(app.dataRoot, 'checkpoint-master.key.legacy-backup'), 'utf8')).toMatch(/^dpapi:v2:/);
+      expect(JSON.parse(await readFile(path.join(app.dataRoot, 'checkpoint-master.key.migration.json'), 'utf8'))).toMatchObject({ operation: 'dpapi_v2' });
+    } finally { await closeDesktop(app); }
+  });
 
   test('normal runtime renders the full first-party catalog and readiness counts', async () => {
     const app = await launchDesktop();
@@ -162,8 +177,20 @@ test.describe('Tools catalog and Doctor real Electron acceptance', () => {
   });
 });
 
-async function launchDesktop(options: { readonly dataRoot?: string; readonly fixtureRoot?: string; readonly pathOverride?: string } = {}): Promise<LaunchedDesktop> {
+async function launchDesktop(options: { readonly dataRoot?: string; readonly fixtureRoot?: string; readonly pathOverride?: string; readonly legacyCheckpoint?: boolean } = {}): Promise<LaunchedDesktop> {
   const dataRoot = options.dataRoot ?? await mkdtemp(path.join(os.tmpdir(), 'lnwjud-tools-doctor-data-'));
+  if (options.legacyCheckpoint) {
+    const powershell = path.join(globalThis.process.env.SystemRoot ?? 'C:\\Windows', 'System32/WindowsPowerShell/v1.0/powershell.exe');
+    const env = Object.fromEntries(Object.entries(globalThis.process.env).filter(([key]) => key.toLowerCase() !== 'psmodulepath'));
+    const sourceHelper = path.join(desktopRoot, '../../native/windows-secret-migrator/bin/win-x64/lnwjud-windows-secret-migrator.exe');
+    if (packagedExecutable === undefined && !existsSync(sourceHelper)) {
+      await promisify(execFile)(powershell, ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', path.join(desktopRoot, '../../scripts/build-windows-secret-migrator.ps1')], { windowsHide: true, env, timeout: 120_000 });
+    }
+    const encrypted = await promisify(execFile)(powershell, ['-NoProfile', '-NonInteractive', '-Command',
+      "Add-Type -AssemblyName System.Security; $bytes = [Text.Encoding]::UTF8.GetBytes('KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio='); [Convert]::ToBase64String([Security.Cryptography.ProtectedData]::Protect($bytes, $null, [Security.Cryptography.DataProtectionScope]::CurrentUser))",
+    ], { windowsHide: true, env });
+    await writeFile(path.join(dataRoot, 'checkpoint-master.key'), `dpapi:v2:${encrypted.stdout.trim()}`);
+  }
   const fixtureRoot = options.fixtureRoot ?? await createFixture();
   const devToolsPort = await findEphemeralPort();
   const mcpPort = await findEphemeralPort();
@@ -183,7 +210,7 @@ async function launchDesktop(options: { readonly dataRoot?: string; readonly fix
     shell: false,
     windowsHide: true,
     env: {
-      ...globalThis.process.env,
+      ...Object.fromEntries(Object.entries(globalThis.process.env).filter(([key]) => packagedExecutable === undefined || key.toLowerCase() !== 'lnwjud_windows_secret_migrator')),
       PATH: effectivePath,
       Path: effectivePath,
       APPDATA: dataRoot,
@@ -193,6 +220,9 @@ async function launchDesktop(options: { readonly dataRoot?: string; readonly fix
       LNWJUD_UNRESTRICTED: '1',
       LNWJUD_E2E_FIXTURE: '1',
       LNWJUD_E2E_NODE_PATH: globalThis.process.execPath,
+      ...(options.legacyCheckpoint && packagedExecutable === undefined ? {
+        LNWJUD_WINDOWS_SECRET_MIGRATOR: path.join(desktopRoot, '../../native/windows-secret-migrator/bin/win-x64/lnwjud-windows-secret-migrator.exe'),
+      } : {}),
     },
   });
   const stderr: string[] = [];

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/desktop",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "description": "Cross-platform local AI-agent runtime and MCP gateway with 232 total tool definitions.",
   "author": "Adisorn",

--- a/apps/desktop/src/main/legacy-secret-migration.ts
+++ b/apps/desktop/src/main/legacy-secret-migration.ts
@@ -234,7 +234,7 @@ async function acquireMigrationLock(lockPath: string, secretPath: string, timeou
 function createNativeHelperRunner(options: { readonly helperPath: string; readonly helperSha256Path?: string }): (request: LegacySecretHelperRequest) => Promise<string> {
   let integrity: Promise<void> | null = null;
   return async (request) => {
-    integrity ??= verifyHelperIntegrity(options.helperPath, options.helperSha256Path ?? `${options.helperPath}.sha256`);
+    integrity ??= verifyHelperIntegrity(options.helperPath, options.helperSha256Path ?? `${options.helperPath.replace(/\.exe$/i, '')}.sha256`);
     await integrity;
     return runHelperProcess(options.helperPath, request);
   };

--- a/apps/desktop/tests/legacy-secret-migration.test.ts
+++ b/apps/desktop/tests/legacy-secret-migration.test.ts
@@ -1,4 +1,7 @@
-import { mkdir, readFile, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, mkdtemp, rm, stat, writeFile, realpath } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
@@ -12,6 +15,61 @@ const TUNNEL_KEY = 'legacy-tunnel-api-key';
 const LEGACY_TUNNEL_HEX = '01000000d08c9ddf0115d1118c7a00c04fc297eb' + 'ab'.repeat(80);
 
 describe('legacy Windows secret migration', () => {
+  it.each([false, true])('checks the helper checksum (explicit override: %s) and preserves legacy data on mismatch', async (explicitOverride) => {
+    const root = await realpath(await mkdtemp(path.join(os.tmpdir(), 'lnwjud-helper-integrity-')));
+    try {
+      const helperPath = path.join(root, 'lnwjud-windows-secret-migrator.exe');
+      const checkpointPath = path.join(root, 'checkpoint-master.key');
+      await writeFile(helperPath, 'invalid helper fixture');
+      const helperSha256Path = path.join(root, explicitOverride ? 'custom-checksum.txt' : 'lnwjud-windows-secret-migrator.sha256');
+      await writeFile(helperSha256Path, `${'0'.repeat(64)}  lnwjud-windows-secret-migrator.exe\n`);
+      await writeFile(checkpointPath, 'dpapi:v2:legacy-fixture');
+      await expect(migrateLegacyWindowsSecrets({
+        platform: 'win32', helperPath, checkpointPath, tunnelSecretPath: path.join(root, 'missing.secret'),
+        ...(explicitOverride ? { helperSha256Path } : {}),
+        secretProtector: createExplicitKeySecretProtector(Buffer.alloc(32, 0x21)),
+      })).rejects.toThrow('Windows secret migration helper integrity check failed');
+      expect(await readFile(checkpointPath, 'utf8')).toBe('dpapi:v2:legacy-fixture');
+      await expect(stat(`${checkpointPath}.legacy-backup`)).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform !== 'win32')('migrates real Windows DPAPI and SecureString values with the shipped native helper', async () => {
+    const exec = promisify(execFile);
+    const repositoryRoot = path.resolve(import.meta.dirname, '../../..');
+    const helperPath = process.env.LNWJUD_TEST_WINDOWS_SECRET_MIGRATOR
+      ?? path.join(repositoryRoot, 'native/windows-secret-migrator/bin/win-x64/lnwjud-windows-secret-migrator.exe');
+    const powershell = path.join(process.env.SystemRoot ?? 'C:\\Windows', 'System32/WindowsPowerShell/v1.0/powershell.exe');
+    const powershellEnv = Object.fromEntries(Object.entries(process.env).filter(([key]) => key.toLowerCase() !== 'psmodulepath'));
+    if (!existsSync(helperPath)) {
+      if (process.env.LNWJUD_TEST_WINDOWS_SECRET_MIGRATOR !== undefined) throw new Error('Configured test helper does not exist');
+      await exec(powershell, ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', path.join(repositoryRoot, 'scripts/build-windows-secret-migrator.ps1')], { windowsHide: true, timeout: 120_000, env: powershellEnv });
+    }
+    const root = await realpath(await mkdtemp(path.join(os.tmpdir(), 'lnwjud-native-migration-')));
+    try {
+      const fixture = await exec(powershell, ['-NoProfile', '-NonInteractive', '-Command',
+        `Add-Type -AssemblyName System.Security; $bytes = [Text.Encoding]::UTF8.GetBytes('${CHECKPOINT_KEY}'); $cipher = [Security.Cryptography.ProtectedData]::Protect($bytes, $null, [Security.Cryptography.DataProtectionScope]::CurrentUser); $secure = ConvertTo-SecureString '${TUNNEL_KEY}' -AsPlainText -Force; @{ checkpoint = [Convert]::ToBase64String($cipher); tunnel = (ConvertFrom-SecureString $secure) } | ConvertTo-Json -Compress`,
+      ], { windowsHide: true, env: powershellEnv });
+      const legacy = JSON.parse(fixture.stdout) as { checkpoint: string; tunnel: string };
+      const checkpointPath = path.join(root, 'checkpoint-master.key');
+      const tunnelSecretPath = path.join(root, 'lnwjud.runtime.secret');
+      await writeFile(checkpointPath, `dpapi:v2:${legacy.checkpoint}`);
+      await writeFile(tunnelSecretPath, legacy.tunnel);
+      const secretProtector = createExplicitKeySecretProtector(Buffer.alloc(32, 0x42));
+      const options = { helperPath, checkpointPath, tunnelSecretPath, secretProtector };
+      expect(await migrateLegacyWindowsSecrets(options)).toEqual({ checkpoint: 'migrated', tunnel: 'migrated' });
+      expect(await secretProtector.decrypt('checkpoint_master_key', await readFile(checkpointPath, 'utf8'))).toMatchObject({ plainText: CHECKPOINT_KEY });
+      expect(await secretProtector.decrypt('tunnel_api_key', await readFile(tunnelSecretPath, 'utf8'))).toMatchObject({ plainText: TUNNEL_KEY });
+      expect(await readFile(`${checkpointPath}.legacy-backup`, 'utf8')).toBe(`dpapi:v2:${legacy.checkpoint}`);
+      expect(await readFile(`${tunnelSecretPath}.legacy-backup`, 'utf8')).toBe(legacy.tunnel);
+      expect(await migrateLegacyWindowsSecrets(options)).toEqual({ checkpoint: 'already_safe', tunnel: 'already_safe' });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 150_000);
+
   it('migrates every persisted OAuth/ngrok secret using the existing startup arguments', async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), 'lnwjud-oauth-migration-'));
     try {

--- a/apps/desktop/tests/mutation-safety-ui.test.ts
+++ b/apps/desktop/tests/mutation-safety-ui.test.ts
@@ -99,13 +99,13 @@ function recoveryMarkup(locale: 'th' | 'en'): string {
 }
 
 describe('mutation safety UI contract', () => {
-  it('renders the actual 4.56.0 application version', () => {
-    expect(APP_VERSION).toBe('4.56.0');
+  it('renders the actual 4.56.1 application version', () => {
+    expect(APP_VERSION).toBe('4.56.1');
     const markup = renderToStaticMarkup(createElement(AppShell, {
       locale: 'en', appVersion: APP_VERSION, mcpRunning: false, desktopFullBypassOn: false, stdioFullBypassOn: false, updateStatus: null, screen: 'settings',
       onNavigate: () => undefined, onLocaleChange: () => undefined, onUpdateAction: () => undefined, children: createElement('div'),
     }));
-    expect(markup).toContain('v4.56.0');
+    expect(markup).toContain('v4.56.1');
   });
 
   it('keeps Desktop and STDIO Full Bypass independently visible in the application header', () => {

--- a/docs/LNWJUD_CAPABILITIES.md
+++ b/docs/LNWJUD_CAPABILITIES.md
@@ -1,6 +1,6 @@
 # lnwjud — สรุปความสามารถทั้งหมด
 
-สถานะเอกสาร: สรุปจาก source และ runtime contract ปัจจุบันของ lnwjud v4.56.0 (มีทั้งหมด 231 definitions; advertise 224 tools โดยปริยายก่อนใช้ per-tool override และครบ 231 tools เมื่อเปิด Codex delegation กับ Agent Swarm)
+สถานะเอกสาร: สรุปจาก source และ runtime contract ปัจจุบันของ lnwjud v4.56.1 (มีทั้งหมด 231 definitions; advertise 224 tools โดยปริยายก่อนใช้ per-tool override และครบ 231 tools เมื่อเปิด Codex delegation กับ Agent Swarm)
 ขอบเขต: ความสามารถของ gateway, MCP tools, การเชื่อมต่อ AI, สิทธิ์, Live Logs และข้อจำกัดในการใช้งาน
 เอกสารนี้ถูกติดตามใน repository และต้องสอดคล้องกับ source, runtime contract และ release ปัจจุบัน
 
@@ -8,7 +8,7 @@
 
 lnwjud ไม่ใช่ AI model และไม่ใช่ provider API aggregator แต่เป็น Windows-first local development gateway ที่เปิดความสามารถของเครื่องและ workspace ให้ AI host ที่พูดภาษา Model Context Protocol (MCP) ได้
 
-ความสามารถหลักใน v4.56.0 คือ:
+ความสามารถหลักใน v4.56.1 คือ:
 
 - เปิด workspace และ machine roots ให้ AI อ่าน ค้นหา วิเคราะห์ และแก้ไขไฟล์ได้
 - ใช้ Context Economy Engine ลด I/O/token จากการค้นหาอัตโนมัติ โดยยังอ่าน .env, .git, dist และ node_modules ได้เมื่อร้องขอแบบ explicit และอยู่ในขอบเขตที่ workspace/path policy อนุญาต

--- a/docs/USAGE_TH.md
+++ b/docs/USAGE_TH.md
@@ -1,4 +1,4 @@
-# คู่มือใช้งาน lnwjud v4.56.0 (ภาษาไทย)
+# คู่มือใช้งาน lnwjud v4.56.1 (ภาษาไทย)
 
 lnwjud คือ cross-platform local AI-agent runtime / MCP gateway สำหรับให้ ChatGPT, Codex และ MCP client อื่นทำงานกับเครื่องของคุณ เช่น อ่าน/ค้น/แก้ไฟล์, Git, รันโปรเซส และเครื่องมือพัฒนาอื่น ๆ โดยงานจริงยังทำบนเครื่องของคุณ ความสามารถ Windows-only เช่น WSL, Registry และ Windows Sandbox จะไม่แสดงเป็นพร้อมใช้งานบน macOS/Linux
 
@@ -27,7 +27,7 @@ Outlook/COM ยังคงเป็น Windows-only และจะรายง
 สำหรับ v4.11.0 ตัวโปรแกรมแยก compatibility profile ตามระบบ: Windows 10 x64 ใช้ software rendering เป็นค่าเริ่มต้นเพื่อลดปัญหาหน้าจอ Electron/Chromium ค้าง, วาดไม่ครบ หรือบาง control กดไม่ได้บน GPU/driver รุ่นเก่า ส่วน Windows 11 x64 ยังใช้ hardware acceleration ตามปกติ
 
 งานภายในโปรแกรมที่ต้องเรียก PowerShell ใช้ `powershell.exe` ที่มากับ Windows ไม่บังคับให้ติดตั้ง PowerShell 7 และ child process ภายในถูกเปิดแบบซ่อนหน้าต่าง console. ระบบยังจำกัด durable background task พร้อมกันไว้ 16 งาน และ managed process พร้อมกันไว้ 24 งาน เพื่อกันกรณีหลายแชทสั่งงานพร้อมกันจนเกิด `conhost.exe` จำนวนมาก/CPU เต็ม
-- `lnwjud-Setup-4.56.0.exe` หรือ `lnwjud-Portable-4.56.0.exe`
+- `lnwjud-Setup-4.56.1.exe` หรือ `lnwjud-Portable-4.56.1.exe`
 - OpenAI Platform tunnel ที่ผูกกับ ChatGPT workspace ที่จะใช้
 - Credential ตามโหมดที่เลือก: **OAuth** เมื่อ provider รองรับ Tunnel provisioning หรือ **Runtime API key** ที่มีสิทธิ์ **Tunnels Read + Use** สำหรับโหมดเดิม/สำรอง
 - อินเทอร์เน็ตขาออก HTTPS สำหรับ Secure MCP Tunnel
@@ -47,7 +47,7 @@ Node.js, pnpm และ Git จำเป็นเฉพาะกรณีพั�
 
 ### แบบแนะนำ: Installer
 
-1. ดาวน์โหลด `lnwjud-Setup-4.56.0.exe` จาก GitHub Releases
+1. ดาวน์โหลด `lnwjud-Setup-4.56.1.exe` จาก GitHub Releases
 2. ติดตั้งตามปกติ
 3. เปิด **lnwjud Agent Control Center**
 4. เพิ่ม Project/Workspace ที่ต้องการใช้งาน
@@ -55,7 +55,7 @@ Node.js, pnpm และ Git จำเป็นเฉพาะกรณีพั�
 
 ### แบบไม่ต้องติดตั้ง: Portable EXE
 
-1. ดาวน์โหลด `lnwjud-Portable-4.56.0.exe`
+1. ดาวน์โหลด `lnwjud-Portable-4.56.1.exe`
 2. วางไว้ในโฟลเดอร์ที่ต้องการแล้วเปิดไฟล์ได้ทันที ไม่ต้องรัน installer
 3. เพิ่ม Project/Workspace และตั้ง Tunnel เหมือนเวอร์ชันติดตั้ง
 
@@ -332,8 +332,8 @@ corepack pnpm@10.15.0 package:windows
 ไฟล์ที่ได้จะอยู่ที่:
 
 ```text
-apps/desktop/dist/installers/lnwjud-Setup-4.56.0.exe
-apps/desktop/dist/installers/lnwjud-Portable-4.56.0.exe
+apps/desktop/dist/installers/lnwjud-Setup-4.56.1.exe
+apps/desktop/dist/installers/lnwjud-Portable-4.56.1.exe
 apps/desktop/dist/installers/latest.yml
 apps/desktop/dist/installers/portable.yml
 ```

--- a/docs/architecture/MULTI_WORKSPACE_CONCURRENCY.md
+++ b/docs/architecture/MULTI_WORKSPACE_CONCURRENCY.md
@@ -6,7 +6,7 @@ Primary invariant: **one lnwjud installation can serve many concurrent AI sessio
 
 The dated phase evidence below preserves the catalog counts that were measured
 at each historical checkpoint (including the earlier 214/208 baseline). The
-current v4.56.0 runtime contract is 232 total definitions, 225 advertised by
+current v4.56.1 runtime contract is 232 total definitions, 225 advertised by
 default, and all 232 when Codex delegation plus Agent Swarm is enabled; see the current catalog and
 release checklist for the authoritative release count.
 

--- a/docs/architecture/TOOL_CONTRACT.md
+++ b/docs/architecture/TOOL_CONTRACT.md
@@ -1,6 +1,6 @@
 # lnwjud tool contract
 
-Status: God-Tier Wave 0–8 additive contract snapshot synchronized for `v4.56.0`.
+Status: God-Tier Wave 0–8 additive contract snapshot synchronized for `v4.56.1`.
 
 This is the compatibility contract for the current MCP surface. The runtime
 advertises the JSON Schema for every input through `tools/list`; the TypeScript

--- a/docs/architecture/UPGRADE_ARCHITECTURE.md
+++ b/docs/architecture/UPGRADE_ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # lnwjud upgrade architecture contract
 
-Status: God-Tier local-first implementation checkpoint synchronized for `v4.56.0`.
+Status: God-Tier local-first implementation checkpoint synchronized for `v4.56.1`.
 
 This document is the architectural boundary for the upgrade roadmap. It describes
 the existing runtime before Phase 01 and the invariants every later phase must

--- a/docs/development/PACKAGING_WINDOWS.md
+++ b/docs/development/PACKAGING_WINDOWS.md
@@ -29,7 +29,7 @@ The package script rebuilds the workspace, generates the current MCP stdio bundl
 
 ## Current electron-builder contract
 
-`apps/desktop/electron-builder.yml` is the source of truth. The current v4.56.0 packaging contract is:
+`apps/desktop/electron-builder.yml` is the source of truth. The current v4.56.1 packaging contract is:
 
 - `asar: true`.
 - Windows x64 targets: NSIS installer + portable executable.
@@ -72,12 +72,12 @@ The `makeappx.exe`/`signtool.exe` steps need the Windows SDK. No certificate or 
 
 ## Expected Windows outputs
 
-For v4.56.0:
+For v4.56.1:
 
 ```text
-apps/desktop/dist/installers/lnwjud-Setup-4.56.0.exe
-apps/desktop/dist/installers/lnwjud-Setup-4.56.0.exe.blockmap
-apps/desktop/dist/installers/lnwjud-Portable-4.56.0.exe
+apps/desktop/dist/installers/lnwjud-Setup-4.56.1.exe
+apps/desktop/dist/installers/lnwjud-Setup-4.56.1.exe.blockmap
+apps/desktop/dist/installers/lnwjud-Portable-4.56.1.exe
 apps/desktop/dist/installers/latest.yml
 apps/desktop/dist/installers/portable.yml
 apps/desktop/dist/installers/SHA256SUMS.txt

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lnwjud",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "engines": {

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/application",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/application/src/agent-swarm-service.ts
+++ b/packages/application/src/agent-swarm-service.ts
@@ -261,7 +261,7 @@ export class AgentSwarmService {
 }
 
 function validateStart(request: AgentSwarmStartRequest): Result<void> {
-  if (request.accessMode !== 'read_only') return err(appError('PERMISSION_DENIED', 'Agent swarm v4.56.0 supports read_only access only'));
+  if (request.accessMode !== 'read_only') return err(appError('PERMISSION_DENIED', 'Agent swarm v4.56.1 supports read_only access only'));
   if (!Array.isArray(request.tasks) || request.tasks.length < 1 || request.tasks.length > MAX_TASKS) return err(appError('INVALID_INPUT', 'Agent swarm requires 1 to 4 tasks'));
   const ids = new Set<string>();
   for (const task of request.tasks) {

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/audit",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/capabilities/package.json
+++ b/packages/capabilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/capabilities",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/codex/package.json
+++ b/packages/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/codex",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/domain",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/extensions",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/filesystem",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/git",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ipc-contracts/package.json
+++ b/packages/ipc-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/ipc-contracts",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ipc-contracts/src/index.ts
+++ b/packages/ipc-contracts/src/index.ts
@@ -1,5 +1,5 @@
 export const APP_NAME = 'lnwjud';
-export const APP_VERSION = '4.56.0';
+export const APP_VERSION = '4.56.1';
 
 export const ipcChannels = {
   listWorkspaces: 'lnwjud:list-workspaces',

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/mcp-server",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/mcp-server/src/tool-registry.ts
+++ b/packages/mcp-server/src/tool-registry.ts
@@ -992,7 +992,7 @@ function summarizeMutationForApproval(toolName: string, input: unknown, activeWo
       lines.push(`launchCount = ${taskIds.length}`);
       if (taskIds.length > 0) lines.push(`taskIds = ${JSON.stringify(taskIds)}`);
     }
-    lines.push('WARNING: this consumes explicitly enabled Codex quota; v4.56.0 enforces read-only child sandboxes.');
+    lines.push('WARNING: this consumes explicitly enabled Codex quota; v4.56.1 enforces read-only child sandboxes.');
     return boundedApprovalSummary(lines);
   }
   const projectKind = projectCommandKind(toolName);

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/permissions",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/process",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/project",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/search",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/shared",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,5 @@
 export const APP_NAME = 'lnwjud';
-export const APP_VERSION = '4.56.0';
+export const APP_VERSION = '4.56.1';
 export { isUnrestricted, unrestrictedFromEnv, unrestrictedFromSetting, UNRESTRICTED_SETTING_KEY, type ProcessEnvLike } from './unrestricted.js';
 
 export { resolveLnwjudDataPath, type DataPathEnvironment } from './data-path.js';

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/storage",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnwjud/workspace",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/repair-windows-4.56.0-startup.ps1
+++ b/scripts/repair-windows-4.56.0-startup.ps1
@@ -1,0 +1,49 @@
+# Repairs only the official v4.56.0 Windows helper metadata filename.
+# No user data, secrets, application binaries, or existing files are replaced.
+[CmdletBinding()]
+param(
+    [string]$InstallDirectory = (Join-Path $env:LOCALAPPDATA 'Programs\lnwjud')
+)
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path -LiteralPath $InstallDirectory).ProviderPath
+$directory = Join-Path $root 'resources\windows-secret-migrator'
+$helper = Join-Path $directory 'lnwjud-windows-secret-migrator.exe'
+$source = Join-Path $directory 'lnwjud-windows-secret-migrator.sha256'
+$destination = Join-Path $directory 'lnwjud-windows-secret-migrator.exe.sha256'
+
+# This digest comes from the published v4.56.0 Windows provenance.
+$expected = '5a6c64343000a2a100e12742fa1240f192817d48cb5981e9644c9d291c491afe'
+foreach ($file in @($helper, $source)) {
+    $item = Get-Item -LiteralPath $file -Force
+    if ($item.PSIsContainer) { throw 'Expected a regular release file.' }
+    $cursor = $item
+    while ($null -ne $cursor) {
+        if (($cursor.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+            throw 'Refusing a linked or redirected installation path.'
+        }
+        if ($cursor -is [IO.FileInfo]) { $cursor = $cursor.Directory } else { $cursor = $cursor.Parent }
+    }
+}
+if ((Get-FileHash -LiteralPath $helper -Algorithm SHA256).Hash.ToLowerInvariant() -ne $expected) {
+    throw 'This is not the verified official v4.56.0 helper. No changes made.'
+}
+$metadata = [IO.File]::ReadAllText($source).Trim()
+if ($metadata -notmatch '^([0-9a-fA-F]{64})\s+lnwjud-windows-secret-migrator\.exe$' -or $Matches[1].ToLowerInvariant() -ne $expected) {
+    throw 'Release metadata does not match the verified helper. No changes made.'
+}
+if (Test-Path -LiteralPath $destination) {
+    $existing = Get-Item -LiteralPath $destination -Force
+    if ($existing.PSIsContainer -or ($existing.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw 'Refusing to overwrite existing metadata.'
+    }
+    if ((Get-FileHash -LiteralPath $destination).Hash -ne (Get-FileHash -LiteralPath $source).Hash) {
+        throw 'Existing compatibility metadata differs. No changes made.'
+    }
+    Write-Host 'Already repaired. You can reopen lnwjud.'
+    return
+}
+[IO.File]::Copy($source, $destination, $false)
+if ((Get-FileHash -LiteralPath $destination).Hash -ne (Get-FileHash -LiteralPath $source).Hash) {
+    throw 'Copied metadata verification failed. Do not launch the application.'
+}
+Write-Host 'Startup metadata repaired. Reopen lnwjud. Your data and secrets were not changed.'

--- a/tests/packaging/desktop-packaging.test.ts
+++ b/tests/packaging/desktop-packaging.test.ts
@@ -6,11 +6,11 @@ const desktopRoot = path.resolve(import.meta.dirname, '..', '..', 'apps', 'deskt
 const repositoryRoot = path.resolve(desktopRoot, '..', '..');
 
 describe('cross-platform desktop packaging', () => {
-  it('pins the product release to v4.56.0', async () => {
+  it('pins the product release to v4.56.1', async () => {
     const rootPackage = JSON.parse(await readFile(path.join(repositoryRoot, 'package.json'), 'utf8')) as { version?: unknown };
     const desktopPackage = JSON.parse(await readFile(path.join(desktopRoot, 'package.json'), 'utf8')) as { version?: unknown };
-    expect(rootPackage.version).toBe('4.56.0');
-    expect(desktopPackage.version).toBe('4.56.0');
+    expect(rootPackage.version).toBe('4.56.1');
+    expect(desktopPackage.version).toBe('4.56.1');
   });
 
   it('keeps every workspace package and runtime version aligned', async () => {
@@ -33,12 +33,12 @@ describe('cross-platform desktop packaging', () => {
     }
     for (const packagePath of packagePaths) {
       const packageJson = JSON.parse(await readFile(packagePath, 'utf8')) as { version?: unknown };
-      expect(packageJson.version, packagePath).toBe('4.56.0');
+      expect(packageJson.version, packagePath).toBe('4.56.1');
     }
     const ipcContracts = await readFile(path.join(repositoryRoot, 'packages', 'ipc-contracts', 'src', 'index.ts'), 'utf8');
     const shared = await readFile(path.join(repositoryRoot, 'packages', 'shared', 'src', 'index.ts'), 'utf8');
-    expect(ipcContracts).toContain("APP_VERSION = '4.56.0'");
-    expect(shared).toContain("APP_VERSION = '4.56.0'");
+    expect(ipcContracts).toContain("APP_VERSION = '4.56.1'");
+    expect(shared).toContain("APP_VERSION = '4.56.1'");
   });
 
   it('publishes complete desktop application metadata', async () => {

--- a/tests/release/release-asset-collector.test.ts
+++ b/tests/release/release-asset-collector.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from 'vitest';
 
 const execFileAsync = promisify(execFile);
 const repositoryRoot = path.resolve(import.meta.dirname, '..', '..');
-const version = '4.56.0';
+const version = '4.56.1';
 const commit = '0123456789abcdef0123456789abcdef01234567';
 
 describe('release asset collector', () => {
@@ -45,14 +45,14 @@ describe('release asset collector', () => {
 
       const assetNames = new Set(await readdir(assetsDirectory));
       for (const name of [
-        'lnwjud-Setup-4.56.0.exe',
-        'lnwjud-Portable-4.56.0.exe',
-        'lnwjud-4.56.0-arm64.dmg',
-        'lnwjud-4.56.0-arm64.zip',
-        'lnwjud-4.56.0-x64.dmg',
-        'lnwjud-4.56.0-x64.zip',
-        'lnwjud-4.56.0-x64.AppImage',
-        'lnwjud-4.56.0-arm64.AppImage',
+        'lnwjud-Setup-4.56.1.exe',
+        'lnwjud-Portable-4.56.1.exe',
+        'lnwjud-4.56.1-arm64.dmg',
+        'lnwjud-4.56.1-arm64.zip',
+        'lnwjud-4.56.1-x64.dmg',
+        'lnwjud-4.56.1-x64.zip',
+        'lnwjud-4.56.1-x64.AppImage',
+        'lnwjud-4.56.1-arm64.AppImage',
         'latest-linux.yml',
         'latest-linux-arm64.yml',
         'latest-mac.yml',
@@ -64,8 +64,8 @@ describe('release asset collector', () => {
         expect(assetNames.has(name), name).toBe(true);
       }
       const macManifest = await readFile(path.join(assetsDirectory, 'latest-mac.yml'), 'utf8');
-      expect(macManifest).toContain('lnwjud-4.56.0-arm64.zip');
-      expect(macManifest).toContain('lnwjud-4.56.0-x64.zip');
+      expect(macManifest).toContain('lnwjud-4.56.1-arm64.zip');
+      expect(macManifest).toContain('lnwjud-4.56.1-x64.zip');
       for (const name of assetNames) {
         if (!/^SHA256SUMS(?:-.+)?\.txt$/.test(name)) continue;
         const sums = await readFile(path.join(assetsDirectory, name), 'utf8');


### PR DESCRIPTION
Urgent v4.56.1 Windows/macOS/Linux hotfix. Windows legacy-secret startup requested helper.exe.sha256 while shipping helper.sha256; default lookup fixed with integrity and backups retained. Real native DPAPI/SecureString unit tests plus source and packaged legacy-profile startup coverage added, including explicit metadata override and isolation from external helper environment. Main Windows CI now runs the packaged legacy-profile regression before uploading release artifacts. Public v4.56.0 installer RED reproduced exact user error; hash-pinned repair then GREEN. Fresh v4.56.1 local package GREEN with legacy profile and invalid inherited helper override. Clean-worktree full workspace suite passed (Desktop584, MCP923), packaging61, release16; lint/typecheck passed. All-platform CI must pass before merge/tag. Windows11 actual local acceptance; no separate physical Windows10 acceptance claimed. Release immutable new v4.56.1 only; no v4.56.0 retag or profile deletion.