### PR TITLE
fix: retry transient download timeouts during native packaging

### DIFF
--- a/apps/desktop/scripts/fetch-with-retry.mjs
+++ b/apps/desktop/scripts/fetch-with-retry.mjs
@@ -1,0 +1,48 @@
+/* global AbortSignal, fetch, setTimeout */
+
+const RETRYABLE_HTTP_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+const RETRYABLE_ERROR_CODES = new Set([
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_SOCKET',
+  'UND_ERR_DESTROYED',
+  'ECONNRESET',
+  'ECONNABORTED',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+  'ECONNREFUSED',
+  'EPIPE',
+]);
+const MAX_ATTEMPTS = 4;
+
+const sleep = (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs));
+
+function isRetryableFetchError(error) {
+  const code = error?.code ?? error?.cause?.code;
+  const name = error?.name;
+  const causeName = error?.cause?.name;
+  return name === 'TimeoutError'
+    || causeName === 'TimeoutError'
+    || causeName === 'ConnectTimeoutError'
+    || causeName === 'HeadersTimeoutError'
+    || causeName === 'BodyTimeoutError'
+    || causeName === 'SocketError'
+    || RETRYABLE_ERROR_CODES.has(code);
+}
+
+export async function fetchWithRetry(url, timeoutMs, fetchFn = fetch, sleepFn = sleep) {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetchFn(url, { signal: AbortSignal.timeout(timeoutMs) });
+      if (response.ok || !RETRYABLE_HTTP_STATUS.has(response.status) || attempt === MAX_ATTEMPTS) return response;
+      await response.body?.cancel().catch(() => undefined);
+    } catch (error) {
+      if (attempt === MAX_ATTEMPTS || !isRetryableFetchError(error)) throw error;
+    }
+    await sleepFn(1_000 * 2 ** (attempt - 1));
+  }
+  throw new Error('Download retry loop exhausted unexpectedly');
+}

--- a/apps/desktop/scripts/prepare-runtime-tools.mjs
+++ b/apps/desktop/scripts/prepare-runtime-tools.mjs
@@ -1,4 +1,4 @@
-/* global AbortSignal, Buffer, clearTimeout, fetch, process, setTimeout */
+/* global Buffer, clearTimeout, process, setTimeout */
 
 import { createHash } from 'node:crypto';
 import { chmod, copyFile, lstat, mkdir, readFile, readdir, realpath, rename, rm, stat, writeFile } from 'node:fs/promises';
@@ -6,6 +6,7 @@ import { spawn } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
+import { fetchWithRetry } from './fetch-with-retry.mjs';
 
 const require = createRequire(import.meta.url);
 const extractZip = require('@electron-internal/extract-zip');
@@ -145,7 +146,7 @@ async function downloadIfNeeded(url, destination, expectedSha256, label) {
   } catch {
     // Missing or invalid cache entries are downloaded below.
   }
-  const response = await fetch(url, { signal: AbortSignal.timeout(120_000) });
+  const response = await fetchWithRetry(url, 120_000);
   if (!response.ok) throw new Error(`Could not download official ${label} asset (${response.status})`);
   await writeAtomic(destination, Buffer.from(await response.arrayBuffer()));
   await assertCanonicalFile(destination);

--- a/apps/desktop/scripts/prepare-tunnel-client.mjs
+++ b/apps/desktop/scripts/prepare-tunnel-client.mjs
@@ -1,4 +1,4 @@
-/* global AbortSignal, Buffer, clearTimeout, fetch, setTimeout */
+/* global Buffer, clearTimeout, setTimeout */
 
 import { createHash } from 'node:crypto';
 import { copyFile, chmod, lstat, mkdir, readFile, readdir, realpath, rename, rm, stat, writeFile } from 'node:fs/promises';
@@ -8,6 +8,7 @@ import process from 'node:process';
 import { createRequire } from 'node:module';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
+import { fetchWithRetry } from './fetch-with-retry.mjs';
 
 const require = createRequire(import.meta.url);
 const extractZip = require('@electron-internal/extract-zip');
@@ -126,7 +127,7 @@ async function downloadIfNeeded(url, destination, expectedSha256) {
 }
 
 async function downloadText(url, destination) {
-  const response = await fetch(url, { signal: AbortSignal.timeout(120_000) });
+  const response = await fetchWithRetry(url, 120_000);
   if (!response.ok) throw new Error(`Could not download official tunnel-client asset (${response.status})`);
   const bytes = Buffer.from(await response.arrayBuffer());
   await writeAtomic(destination, bytes);
@@ -158,7 +159,7 @@ async function assertCanonicalFile(filePath) {
 }
 
 async function fetchText(url) {
-  const response = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+  const response = await fetchWithRetry(url, 30_000);
   if (!response.ok) throw new Error(`Could not download tunnel-client checksums (${response.status})`);
   return response.text();
 }

--- a/apps/desktop/tests/fetch-with-retry.test.ts
+++ b/apps/desktop/tests/fetch-with-retry.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchWithRetry } from '../scripts/fetch-with-retry.mjs';
+
+describe('fetchWithRetry', () => {
+  it('retries bounded transient HTTP and network failures before succeeding', async () => {
+    const cancel = vi.fn(async () => undefined);
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 503, body: { cancel } })
+      .mockRejectedValueOnce(Object.assign(new TypeError('fetch failed'), { cause: { code: 'UND_ERR_CONNECT_TIMEOUT' } }))
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    const sleepFn = vi.fn(async () => undefined);
+
+    await expect(fetchWithRetry('https://example.test/asset', 1234, fetchFn, sleepFn)).resolves.toMatchObject({ ok: true, status: 200 });
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(sleepFn.mock.calls).toEqual([[1000], [2000]]);
+    expect(fetchFn.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('does not retry permanent HTTP failures', async () => {
+    const response = { ok: false, status: 404 };
+    const fetchFn = vi.fn().mockResolvedValue(response);
+    const sleepFn = vi.fn(async () => undefined);
+
+    await expect(fetchWithRetry('https://example.test/missing', 1234, fetchFn, sleepFn)).resolves.toBe(response);
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  it('does not retry non-network exceptions', async () => {
+    const error = Object.assign(new TypeError('invalid URL'), { code: 'ERR_INVALID_URL' });
+    const fetchFn = vi.fn().mockRejectedValue(error);
+    const sleepFn = vi.fn(async () => undefined);
+
+    await expect(fetchWithRetry('bad-url', 1234, fetchFn, sleepFn)).rejects.toBe(error);
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  it('stops after four transient failures', async () => {
+    const error = Object.assign(new TypeError('fetch failed'), { cause: { code: 'UND_ERR_CONNECT_TIMEOUT' } });
+    const fetchFn = vi.fn().mockRejectedValue(error);
+    const sleepFn = vi.fn(async () => undefined);
+
+    await expect(fetchWithRetry('https://example.test/asset', 1234, fetchFn, sleepFn)).rejects.toBe(error);
+    expect(fetchFn).toHaveBeenCalledTimes(4);
+    expect(sleepFn.mock.calls).toEqual([[1000], [2000], [4000]]);
+  });
+
+  it('retries connect timeout causes without explicit error code', async () => {
+    const error = Object.assign(new TypeError('fetch failed'), { cause: { name: 'ConnectTimeoutError' } });
+    const fetchFn = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce({ ok: true, status: 200 });
+    const sleepFn = vi.fn(async () => undefined);
+
+    await expect(fetchWithRetry('https://example.test/asset', 1234, fetchFn, sleepFn)).resolves.toMatchObject({ ok: true, status: 200 });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(sleepFn).toHaveBeenCalledWith(1000);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix transient UND_ERR_CONNECT_TIMEOUT and network timeouts in prepare-runtime-tools.mjs and prepare-tunnel-client.mjs by introducing fetchWithRetry with exponential backoff.
- Add unit tests in apps/desktop/tests/fetch-with-retry.test.ts.

## Verification
- Local: full test suite, platform contract tests, packaging tests, release-gate tests, lint, typecheck all passed.
- GitHub CI on dev:
  - Dev Windows Installer (34437097090) passed.
  - CI (34437097201) passed all jobs (Native Platform Contract Windows/macOS/Linux, Native Package Verification macOS x64, macOS arm64, Linux x64, Linux arm64).